### PR TITLE
Scout Tracker migration

### DIFF
--- a/classes.js
+++ b/classes.js
@@ -96,6 +96,14 @@ class ScouterCheck {
 		this.guild_name = name
 	}
 
+	set _scouters (scoutTracker) {
+		this.scoutTracker = scoutTracker
+	}
+
+	get _scouters () {
+		return this.scoutTracker
+	}
+
 	get _client () {
 		return this.client
 	}
@@ -121,11 +129,11 @@ class ScouterCheck {
 	get potentialScouts () {
 		let scout
 		if (this.roleName.toLowerCase() === 'scouter') {
-			scout = this._db.merchChannel.scoutTracker.filter(val => {
+			scout = this._scouters.filter(val => {
 				return this._checkScouts(val, this.value ?? 40, this.week)
 			})
 		} else if (this.roleName.toLowerCase() === 'verified scouter') {
-			scout = this._db.merchChannel.scoutTracker.filter(val => {
+			scout = this._scouters.filter(val => {
 				return this._checkVerifiedScouts(val, this.value ?? 100, this.month)
 			})
 		} else {
@@ -143,7 +151,7 @@ class ScouterCheck {
 	}
 
 	get scouts () {
-		return this._db.merchChannel.scoutTracker.filter(scouts => {
+		return this._scouters.filter(scouts => {
 			return scouts.assigned.length >= 1
 		})
 	}
@@ -226,10 +234,8 @@ class ScouterCheck {
 	}
 
 	async removeInactive () {
-		const db = await this._db
-
 		return new Promise(async (resolve) => {
-			let merch = await db.merchChannel.scoutTracker
+			let merch = this._scouters
 			merch = merch.filter(doc => {
 				const totalCount = (doc.count + (doc.otherCount ?? 0)) < 10
 				const timeGone = 1000 * 60 * 60 * 24 * 31

--- a/commands/all/dsf.js
+++ b/commands/all/dsf.js
@@ -238,7 +238,7 @@ export default {
 			switch (param) {
 			case 'add':
 				if (!num) {
-					await scouters.updateOne({ userID: userMention }, {
+					await scouters.collection.updateOne({ userID: userMention }, {
 						$inc: {
 							count: 1
 						}
@@ -246,7 +246,7 @@ export default {
 					if (reaction) return message.react('✅')
 					else return message.react('❌')
 				} else if (num === 'other') {
-					await scouters.updateOne({ userID: userMention }, {
+					await scouters.collection.updateOne({ userID: userMention }, {
 						$inc: {
 							otherCount: 1
 						}
@@ -254,7 +254,7 @@ export default {
 					if (reaction) return message.react('✅')
 					else return message.react('❌')
 				} else if (num === 'game') {
-					await scouters.updateOne({ userID: userMention }, {
+					await scouters.collection.updateOne({ userID: userMention }, {
 						$inc: {
 							game: 1
 						}
@@ -267,7 +267,7 @@ export default {
 					} else { num = +num }
 					const other = args.slice(4)
 					if (other[0] === 'other') {
-						await scouters.updateOne({ userID: userMention }, {
+						await scouters.collection.updateOne({ userID: userMention }, {
 							$inc: {
 								otherCount: +num
 							}
@@ -275,7 +275,7 @@ export default {
 						if (reaction) return message.react('✅')
 						else return message.react('❌')
 					} else {
-						await scouters.updateOne({ userID: userMention }, {
+						await scouters.collection.updateOne({ userID: userMention }, {
 							$inc: {
 								count: +num
 							}
@@ -286,7 +286,7 @@ export default {
 				}
 			case 'remove':
 				if (!num) {
-					await scouters.updateOne({ userID: userMention }, {
+					await scouters.collection.updateOne({ userID: userMention }, {
 						$inc: {
 							count: -1
 						}
@@ -294,7 +294,7 @@ export default {
 					if (reaction) return message.react('✅')
 					else return message.react('❌')
 				} else if (num === 'other') {
-					await scouters.updateOne({ userID: userMention }, {
+					await scouters.collection.updateOne({ userID: userMention }, {
 						$inc: {
 							otherCount: -1
 						}
@@ -302,7 +302,7 @@ export default {
 					if (reaction) return message.react('✅')
 					else return message.react('❌')
 				} else if (num === 'game') {
-					await scouters.updateOne({ userID: userMention }, {
+					await scouters.collection.updateOne({ userID: userMention }, {
 						$inc: {
 							game: -1
 						}
@@ -315,7 +315,7 @@ export default {
 					} else { num = +num }
 					const other = args.slice(4)
 					if (other[0] === 'other') {
-						await scouters.updateOne({ userID: userMention }, {
+						await scouters.collection.updateOne({ userID: userMention }, {
 							$inc: {
 								otherCount: -num
 							}
@@ -323,7 +323,7 @@ export default {
 						if (reaction) return message.react('✅')
 						else return message.react('❌')
 					} else {
-						await scouters.updateOne({ userID: userMention }, {
+						await scouters.collection.updateOne({ userID: userMention }, {
 							$inc: {
 								count: -num
 							}

--- a/commands/all/dsf.js
+++ b/commands/all/dsf.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-shadow */
 /* eslint-disable no-useless-escape */
+import { MongoCollection } from '../../DataBase.js'
 import { nEmbed, checkNum, removeMessage } from '../../functions.js'
 import { cream, cyan } from '../../colors.js'
 import { ScouterCheck } from '../../classes.js'
@@ -20,6 +21,7 @@ export default {
 	run: async (client, message, args, perms, db) => {
 		if (!perms.admin) return message.channel.send(perms.errorA)
 		const channels = await db.channels
+		const scouters = new MongoCollection('ScoutTracker')
 
 		switch (args[0]) {
 		case 'm':
@@ -236,25 +238,25 @@ export default {
 			switch (param) {
 			case 'add':
 				if (!num) {
-					await db.collection.updateOne({ _id: message.guild.id, 'merchChannel.scoutTracker.userID': userMention }, {
+					await scouters.updateOne({ userID: userMention }, {
 						$inc: {
-							'merchChannel.scoutTracker.$.count': 1
+							count: 1
 						}
 					})
 					if (reaction) return message.react('✅')
 					else return message.react('❌')
 				} else if (num === 'other') {
-					await db.collection.updateOne({ _id: message.guild.id, 'merchChannel.scoutTracker.userID': userMention }, {
+					await scouters.updateOne({ userID: userMention }, {
 						$inc: {
-							'merchChannel.scoutTracker.$.otherCount': 1
+							otherCount: 1
 						}
 					})
 					if (reaction) return message.react('✅')
 					else return message.react('❌')
 				} else if (num === 'game') {
-					await db.collection.updateOne({ _id: message.guild.id, 'merchChannel.scoutTracker.userID': userMention }, {
+					await scouters.updateOne({ userID: userMention }, {
 						$inc: {
-							'merchChannel.scoutTracker.$.game': 1
+							game: 1
 						}
 					})
 					if (reaction) return message.react('✅')
@@ -265,17 +267,17 @@ export default {
 					} else { num = +num }
 					const other = args.slice(4)
 					if (other[0] === 'other') {
-						await db.collection.updateOne({ _id: message.guild.id, 'merchChannel.scoutTracker.userID': userMention }, {
+						await scouters.updateOne({ userID: userMention }, {
 							$inc: {
-								'merchChannel.scoutTracker.$.otherCount': +num
+								otherCount: +num
 							}
 						})
 						if (reaction) return message.react('✅')
 						else return message.react('❌')
 					} else {
-						await db.collection.updateOne({ _id: message.guild.id, 'merchChannel.scoutTracker.userID': userMention }, {
+						await scouters.updateOne({ userID: userMention }, {
 							$inc: {
-								'merchChannel.scoutTracker.$.count': +num
+								count: +num
 							}
 						})
 						if (reaction) return message.react('✅')
@@ -284,25 +286,25 @@ export default {
 				}
 			case 'remove':
 				if (!num) {
-					await db.collection.updateOne({ _id: message.guild.id, 'merchChannel.scoutTracker.userID': userMention }, {
+					await scouters.updateOne({ userID: userMention }, {
 						$inc: {
-							'merchChannel.scoutTracker.$.count': -1
+							count: -1
 						}
 					})
 					if (reaction) return message.react('✅')
 					else return message.react('❌')
 				} else if (num === 'other') {
-					await db.collection.updateOne({ _id: message.guild.id, 'merchChannel.scoutTracker.userID': userMention }, {
+					await scouters.updateOne({ userID: userMention }, {
 						$inc: {
-							'merchChannel.scoutTracker.$.otherCount': -1
+							otherCount: -1
 						}
 					})
 					if (reaction) return message.react('✅')
 					else return message.react('❌')
 				} else if (num === 'game') {
-					await db.collection.updateOne({ _id: message.guild.id, 'merchChannel.scoutTracker.userID': userMention }, {
+					await scouters.updateOne({ userID: userMention }, {
 						$inc: {
-							'merchChannel.scoutTracker.$.game': -1
+							game: -1
 						}
 					})
 					if (reaction) return message.react('✅')
@@ -313,17 +315,17 @@ export default {
 					} else { num = +num }
 					const other = args.slice(4)
 					if (other[0] === 'other') {
-						await db.collection.updateOne({ _id: message.guild.id, 'merchChannel.scoutTracker.userID': userMention }, {
+						await scouters.updateOne({ userID: userMention }, {
 							$inc: {
-								'merchChannel.scoutTracker.$.otherCount': -num
+								otherCount: -num
 							}
 						})
 						if (reaction) return message.react('✅')
 						else return message.react('❌')
 					} else {
-						await db.collection.updateOne({ _id: message.guild.id, 'merchChannel.scoutTracker.userID': userMention }, {
+						await scouters.updateOne({ userID: userMention }, {
 							$inc: {
-								'merchChannel.scoutTracker.$.count': -num
+								count: -num
 							}
 						})
 						if (reaction) return message.react('✅')

--- a/commands/all/profile.js
+++ b/commands/all/profile.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-shadow */
 /* eslint-disable no-inline-comments */
+import { MongoCollection } from '../../DataBase.js'
 import { MessageEmbed } from 'discord.js'
 import { aqua } from '../../colors.js'
 import ms from 'pretty-ms'
@@ -13,13 +14,14 @@ export default {
 	guildSpecific: ['420803245758480405', '668330890790699079'],
 	permissionLevel: 'Everyone',
 	run: async (client, message, args, perms, db) => {
+		const scouters = new MongoCollection('ScoutTracker')
 		const channels = await db.channels
 		const memberID = message.member.id
-		const data = await db.collection.findOne({ _id: message.guild.id, 'merchChannel.scoutTracker.userID': memberID }, { projection: { 'merchChannel.scoutTracker': 1 } })
+		const data = await scouters.collection.findOne({ userID: memberID })
 		const botRole = message.guild.me.roles.cache.find(r => r.managed)
 		const memberRoles = message.member.roles.highest.position
 
-		const sendUserInfo = async (id = memberID, uData = { scoutTracker: data.merchChannel.scoutTracker }) => {
+		const sendUserInfo = async (id = memberID, uData = { scoutTracker: scouters }) => {
 			const fetchedMember = await message.guild.members.fetch(id)
 			const embed = new MessageEmbed()
 				.setTitle(`Member Profile - ${id}`)
@@ -28,7 +30,7 @@ export default {
 				.setThumbnail(message.author.displayAvatarURL())
 				.setFooter('Something wrong or missing? Let a Moderator+ know!', client.user.displayAvatarURL())
 				.setTimestamp()
-			const userData = uData.scoutTracker.filter(mem => mem.userID === id)
+			const userData = [await uData.scoutTracker.collection.findOne({ userID: id })]
 			const memberAssignedRoles = fetchedMember.roles.cache.filter(r => r.id !== message.guild.id && r.position > botRole.position).sort((a, b) => b.position - a.position).map(role => `<@&${role.id}>`)
 			const memberSelfRoles = fetchedMember.roles.cache.filter(r => r.id !== message.guild.id && r.position < botRole.position).map(role => `<@&${role.id}>`)
 			const fields = []
@@ -52,7 +54,7 @@ export default {
 			return message.channel.send({ embeds: [embed.addFields(fields)] })
 		}
 
-		const sendRoleInfo = async (id, rData = { scoutTracker: data.merchChannel.scoutTracker }) => {
+		const sendRoleInfo = async (id, rData = { scoutTracker: scouters }) => {
 			const roleObj = message.guild.roles.cache.get(id)
 			const embed = new MessageEmbed()
 				.setTitle(`Member Profiles - ${roleObj.name}`)
@@ -72,11 +74,9 @@ export default {
 
 			let newArr = []
 			const fields = []
+			rData = await rData.scoutTracker.collection
 			memCollection.forEach(id => {
-				const x = rData.scoutTracker.filter(mem => {
-					if (mem.userID === id) return mem.userID === id
-					else return undefined
-				})
+				const x = rData.findOne({ userID: id })
 				newArr.push(x)
 			})
 			newArr = newArr.flat().sort((a, b) => b.count - a.count)
@@ -96,24 +96,19 @@ export default {
 				message.channel.awaitMessages({ filter, max: 1, time: 60000, errors: ['time'] })
 					.then(async col => {
 						col = col.first()
-						if (col.content === 'no') { return undefined } else {
-							await db.collection.findOneAndUpdate({ _id: message.guild.id },
-								{
-									$addToSet: {
-										'merchChannel.scoutTracker': {
-											userID: col.author.id,
-											author: col.member.nickname ?? col.author.username,
-											firstTimestamp: col.createdTimestamp,
-											firstTimestampReadable: new Date(col.createdTimestamp),
-											lastTimestamp: col.createdTimestamp,
-											lastTimestampReadable: new Date(col.createdTimestamp),
-											count: 0,
-											game: 0,
-											otherCount: 0,
-											assigned: []
-										}
-									}
-								})
+						if (col.content === 'no') { return } else {
+							await scouters.collection.insert({
+								userID: col.author.id,
+								author: col.member.nickname ?? col.author.username,
+								firstTimestamp: col.createdTimestamp,
+								firstTimestampReadable: new Date(col.createdTimestamp),
+								lastTimestamp: col.createdTimestamp,
+								lastTimestampReadable: new Date(col.createdTimestamp),
+								count: 0,
+								game: 0,
+								otherCount: 0,
+								assigned: []
+							})
 							return await col.react('✅') && await message.channel.send({ content: 'Your profile has been created. Re-use the command to view.' })
 						}
 					})
@@ -151,7 +146,7 @@ export default {
 					? sendUserInfo(userMention.id)
 					: message.channel.send({ content: 'You don\'t have permission to use this command.' })
 			} else if (args[0] === 'all') {
-				const { merchChannel: { scoutTracker } } = await db.collection.findOne({ _id: message.guild.id }, { projection: { 'merchChannel.scoutTracker': 1 } })
+				const scoutTracker = await scouters.collection.find({ count: { $gte: 15 } }).toArray()
 				const items = scoutTracker.sort((a, b) => b.count - a.count)
 				let fields = []
 
@@ -169,7 +164,7 @@ export default {
 					.catch(async err => channels.errors.send(err))
 			} else if (args[0] === 'active') {
 				if (memberRoles < botRole.position) return
-				const { merchChannel: { scoutTracker } } = await db.collection.findOne({ _id: message.guild.id }, { projection: { 'merchChannel.scoutTracker': 1 } })
+				const scoutTracker = await scouters.collection.find({ count: { $gte: 15 } }).toArray()
 				const items = scoutTracker.filter(profile => profile.active).sort((a, b) => b.count - a.count)
 				let fields = []
 
@@ -187,7 +182,7 @@ export default {
 					.catch(async err => channels.errors.send(err))
 			} else if (args[0] === 'inactive') {
 				if (memberRoles < botRole.position) return
-				const { merchChannel: { scoutTracker } } = await db.collection.findOne({ _id: message.guild.id }, { projection: { 'merchChannel.scoutTracker': 1 } })
+				const scoutTracker = await scouters.collection.find({ count: { $gte: 15 } }).toArray()
 				const items = scoutTracker.filter(profile => !profile.active).sort((a, b) => a.lastTimestamp - b.lastTimestamp)
 				let fields = []
 

--- a/dsf/merch/main.js
+++ b/dsf/merch/main.js
@@ -20,7 +20,7 @@ const dsf = async (client, message, db) => {
 					return await message.channel.messages.fetch(messageID[4]).then(x => x.delete()).catch(async (err) => channels.errors.send(err))
 				})
 			:	setTimeout(() => message.delete(), 200)
-		await addMerchCount(client, message, db)
+		await addMerchCount(client, message, db, scouters)
 		skullTimer(message, db)
 	} else if (message.channel.id === otherChannelID) {
 		if (!otherCalls.test(message.content) || !arrIncludesString(disallowedWords, message.content) || !alreadyCalled(message, otherMessages)) {

--- a/dsf/merch/main.js
+++ b/dsf/merch/main.js
@@ -1,9 +1,11 @@
+import { MongoCollection } from '../../DataBase.js'
 import { merchRegex, otherCalls } from './constants.js'
 import { arrIncludesString, alreadyCalled } from './merchFunctions.js'
 import { addMerchCount, skullTimer, addOtherCount, otherTimer } from '../index.js'
 
 const dsf = async (client, message, db) => {
 	const channels = await db.channels
+	const scouters = new MongoCollection('ScoutTracker')
 	const { merchChannel: { channelID, otherChannelID, messages, otherMessages }, disallowedWords } = await db.collection.findOne({ _id: message.guild.id, merchChannel: { $exists: true } }, { projection: { 'merchChannel.channelID': 1, 'merchChannel.otherChannelID': 1, 'merchChannel.messages': 1, disallowedWords: 1, 'merchChannel.otherMessages': 1 } })
 
 	if (message.author.bot) return
@@ -24,7 +26,7 @@ const dsf = async (client, message, db) => {
 		if (!otherCalls.test(message.content) || !arrIncludesString(disallowedWords, message.content) || !alreadyCalled(message, otherMessages)) {
 			return message.delete()
 		}
-		await addOtherCount(message, db)
+		await addOtherCount(message, db, scouters)
 		otherTimer(message, db)
 	}
 }

--- a/dsf/merch/merchChannel/merchCount.js
+++ b/dsf/merch/merchChannel/merchCount.js
@@ -1,13 +1,11 @@
-import { MongoCollection } from '../../../DataBase.js'
 import { merchRegex } from '../constants.js'
 import { checkMemberRole, arrIncludesString, alreadyCalled } from '../merchFunctions.js'
 import { MessageActionRow, MessageButton } from 'discord.js'
 
-export const addMerchCount = async (client, message, db) => {
+export const addMerchCount = async (client, message, db, scouter) => {
 	const channels = await db.channels
 	try {
 		const { merchChannel: { channelID, messages }, disallowedWords } = await db.collection.findOne({ _id: message.guild.id }, { projection: { 'merchChannel.channelID': 1, 'merchChannel.messages': 1, disallowedWords: 1 } })
-		const scouter = new MongoCollection('ScoutTracker')
 		const merchChannelID = client.channels.cache.get(channelID)
 		const botServerErrorChannel = await client.channels.cache.get('784543962174062608')
 		const dsfServerErrorChannel = await client.channels.cache.get('794608385106509824')

--- a/dsf/merch/otherCalls/otherCount.js
+++ b/dsf/merch/otherCalls/otherCount.js
@@ -1,46 +1,38 @@
-export const addOtherCount = async (message, db) => {
+export const addOtherCount = async (message, db, scouters) => {
 	// Adds count for other events channel
 	const channels = await db.channels
 	try {
-		const { merchChannel: { scoutTracker } } = await db.collection.findOne({ _id: message.guild.id }, { projection: { 'merchChannel.scoutTracker': 1 } })
 		const mesOne = await message.channel.messages.fetch({ limit: 1 })
 		const logOne = [...mesOne.values()]
 		const msg = logOne.map(val => val)
 
-		const findMessage = await scoutTracker.find(x => x.userID === msg[0].author.id)
+		const findMessage = await scouters.collection.findOne({ userID: msg[0].author.id })
 		if (!findMessage) {
 			console.log(`New other: ${msg[0].author.username} (${message.content})`, msg[0].author.id)
-			await db.collection.findOneAndUpdate({ _id: message.guild.id },
-				{
-					$addToSet: {
-						'merchChannel.scoutTracker': {
-							$each: [{
-								userID: msg[0].author.id,
-								author: msg[0].member.nickname ?? msg[0].author.username,
-								firstTimestamp: msg[0].createdTimestamp,
-								firstTimestampReadable: new Date(msg[0].createdTimestamp),
-								lastTimestamp: msg[0].createdTimestamp,
-								lastTimestampReadable: new Date(msg[0].createdTimestamp),
-								count: 0,
-								game: 0,
-								otherCount: 1,
-								active: 1,
-								assigned: []
-							}]
-						}
-					}
-				})
+			await scouters.collection.insert({
+				userID: msg[0].author.id,
+				author: msg[0].member.nickname ?? msg[0].author.username,
+				firstTimestamp: msg[0].createdTimestamp,
+				firstTimestampReadable: new Date(msg[0].createdTimestamp),
+				lastTimestamp: msg[0].createdTimestamp,
+				lastTimestampReadable: new Date(msg[0].createdTimestamp),
+				count: 0,
+				game: 0,
+				otherCount: 1,
+				active: 1,
+				assigned: []
+			})
 		} else {
 			console.log(`Old other: ${msg[0].author.username} (${message.content})`, msg[0].author.id)
-			await db.collection.updateOne({ _id: message.guild.id, 'merchChannel.scoutTracker.userID': findMessage.userID }, {
+			await scouters.collection.updateOne({ userID: findMessage.userID }, {
 				$inc: {
-					'merchChannel.scoutTracker.$.otherCount': 1
+					otherCount: 1
 				},
 				$set: {
-					'merchChannel.scoutTracker.$.author': msg[0].member?.nickname ?? msg[0].author.username,
-					'merchChannel.scoutTracker.$.lastTimestamp': msg[0].createdTimestamp,
-					'merchChannel.scoutTracker.$.lastTimestampReadable': new Date(msg[0].createdTimestamp),
-					'merchChannel.scoutTracker.$.active': 1
+					author: msg[0].member?.nickname ?? msg[0].author.username,
+					lastTimestamp: msg[0].createdTimestamp,
+					lastTimestampReadable: new Date(msg[0].createdTimestamp),
+					active: 1
 				}
 			})
 		}

--- a/events/client/ready.js
+++ b/events/client/ready.js
@@ -111,14 +111,16 @@ export default async client => {
 	// DSF Activity Posts //
 	cron.schedule('0 */6 * * *', async () => {
 		const res = await db.collection.find({}).toArray()
-		await classVars(scout, 'Deep Sea Fishing', res, client)
-		await classVars(vScout, 'Deep Sea Fishing', res, client);
+		const scouter = new MongoCollection('ScoutTracker')
+		const scouters = await scouter.collection.find({ count: { $gte: 40 } }).toArray()
+		await classVars(scout, 'Deep Sea Fishing', res, client, scouters)
+		await classVars(vScout, 'Deep Sea Fishing', res, client, scouters);
 
 		[scout, vScout].forEach(role => {
-			addedRoles(role, db)
-			removedRoles(role, db)
+			addedRoles(role, scouter)
+			removedRoles(role, scouter)
 		})
-		removeInactives(scout, db)
+		removeInactives(scout, db, scouter)
 
 		// Daily Reset
 		if (new Date().getHours() === 0o0 && new Date().getMinutes() === 0o0) {

--- a/handlers/interactions/buttons.js
+++ b/handlers/interactions/buttons.js
@@ -1,8 +1,10 @@
+import { MongoCollection } from '../../DataBase.js'
 import { MessageButton, MessageActionRow, MessageSelectMenu, MessageEmbed } from 'discord.js'
 import { greenLight } from '../../colors.js'
 
 export const buttons = async (interaction, db, data, cache) => {
 	const channels = await db.channels
+	const scouters = new MongoCollection('ScoutTracker')
 	const generalChannel = interaction.guild.channels.cache.find(c => c.name === 'general')
 	let [userId, user, content, timestamp] = interaction.message.content.split('\n').slice(3)
 	if (user) user = user.split(' ').slice(2).join(' ')
@@ -76,9 +78,9 @@ export const buttons = async (interaction, db, data, cache) => {
 			if (interaction.user.bot) return
 			const item = data.merchChannel.deletions.messages.find(item => item.messageID === interaction.message.id)
 			if (item) {
-				await db.collection.updateOne({ _id: interaction.guild.id, 'merchChannel.scoutTracker.userID': item.authorID }, {
+				await scouters.collection.updateOne({ userID: item.authorID }, {
 					$inc: {
-						'merchChannel.scoutTracker.$.count': -1
+						count: -1
 					}
 				})
 				await db.collection.updateOne({ _id: interaction.guild.id }, {


### PR DESCRIPTION
Moving the scout tracker from the DSF server settings to its own collection. It's more than 5000 records and will increase the performance of:

1) Single query searches of the Scout Tracker.
2) Entire chunk querying with relevant filter ops.
3) All other Members.Settings database info.