### PR TITLE
[codex] remove unused node-fetch dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "googleapis": "^64.0.0",
         "mongodb": "6.3",
         "node-cron": "^4.2.1",
-        "node-fetch": "^2.7.0",
         "pretty-ms": "^9.3.0",
         "uuid": "^11.1.0",
         "winston": "^3.19.0"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "googleapis": "^64.0.0",
     "mongodb": "6.3",
     "node-cron": "^4.2.1",
-    "node-fetch": "^2.7.0",
     "pretty-ms": "^9.3.0",
     "uuid": "^11.1.0",
     "winston": "^3.19.0"


### PR DESCRIPTION
## What changed

- Removed the unused direct `node-fetch` dependency from `package.json`.
- Updated the root dependency list in `package-lock.json`.

## Why

ValenceBot runs on Node.js 22 and uses the built-in global `fetch`. The codebase does not import `node-fetch`, so keeping it as a direct dependency adds unnecessary dependency surface. Dependabot PR #208 was closed in favor of this removal.

Transitive copies required by other packages remain managed in the lockfile.

## Validation

- `npm ci --ignore-scripts`
- `npx eslint .` (0 errors; one pre-existing `object-shorthand` warning in `src/dsf/calls/counts.js`)
- `git diff --check`
