### PR TITLE
[codex] fix MongoDB find-and-update result handling

### DIFF
--- a/src/commands/fact.js
+++ b/src/commands/fact.js
@@ -97,14 +97,18 @@ export default {
 					const newMessage = args.slice(2).join(' ')
 					if (args[1] && args[2]) {
 						await vFactsColl
-							.findOneAndUpdate({ number: Number(args[1]) }, { $set: { Message: newMessage } })
+							.findOneAndUpdate(
+								{ number: Number(args[1]) },
+								{ $set: { Message: newMessage } },
+								{ returnDocument: 'before' }
+							)
 							.then(async (r) => {
-								await vFactsColl.findOne({ number: r.value.number }).then(async (rs) => {
+								await vFactsColl.findOne({ number: r.number }).then(async (rs) => {
 									message.channel.send({
-										content: `Fact #${rs.number} has been edited successfully!\n${code}${r.value.number}. ${r.value.Message} >>> ${rs.Message}${code}`
+										content: `Fact #${rs.number} has been edited successfully!\n${code}${r.number}. ${r.Message} >>> ${rs.Message}${code}`
 									})
 									channels.logs.send(
-										`<@${message.author.id}> edited Fact #${rs.number}: ${code}diff\n- ${r.value.Message}\n+ ${rs.Message}${code}`
+										`<@${message.author.id}> edited Fact #${rs.number}: ${code}diff\n- ${r.Message}\n+ ${rs.Message}${code}`
 									)
 								})
 							})

--- a/src/commands/settings.js
+++ b/src/commands/settings.js
@@ -52,14 +52,14 @@ export default {
 									.findOneAndUpdate(
 										{ _id: message.guild.id },
 										{ $set: { prefix: args[2] } },
-										{ returnOriginal: true }
+										{ returnDocument: 'before' }
 									)
 									.then(async (r) => {
 										message.channel.send({
-											content: `Prefix has been changed from \`${r.value.prefix}\` to \`${args[2]}\``
+											content: `Prefix has been changed from \`${r.prefix}\` to \`${args[2]}\``
 										})
 										dbChannels.send(
-											`<@${message.author.id}> changed the bot Prefix in server: **${message.guild.name}**\n\`\`\`diff\n- ${r.value.prefix}\n+ ${args[2]}\`\`\``
+											`<@${message.author.id}> changed the bot Prefix in server: **${message.guild.name}**\n\`\`\`diff\n- ${r.prefix}\n+ ${args[2]}\`\`\``
 										)
 									})
 									.catch(async (err) => {
@@ -86,28 +86,28 @@ export default {
 							const found = await db.findOneAndUpdate(
 								{ _id: message.guild.id },
 								{ $set: { 'roles.adminRole': `<@&${args[2]}>` } },
-								{ returnOriginal: true }
+								{ returnDocument: 'before' }
 							)
 							message.channel.send({
 								content: `The Admin Role has been changed to: <@&${args[2]}>`,
 								allowedMentions: { parse: [] }
 							})
 							dbChannels.send(
-								`<@${message.author.id}> changed the adminRole in server: **${message.guild.name}**\n\`\`\`diff\n- ${found.value.roles.adminRole}\n+ <@&${args[2]}>\`\`\``
+								`<@${message.author.id}> changed the adminRole in server: **${message.guild.name}**\n\`\`\`diff\n- ${found.roles.adminRole}\n+ <@&${args[2]}>\`\`\``
 							)
 						} else if (roleName && message.guild.roles.cache.get(roleName.id).permissions.has('Administrator')) {
 							// Setting role by name
 							const found = await db.findOneAndUpdate(
 								{ _id: message.guild.id },
 								{ $set: { 'roles.adminRole': `<@&${roleName.id}>` } },
-								{ returnOriginal: true }
+								{ returnDocument: 'before' }
 							)
 							message.channel.send({
 								content: `The Admin Role has been changed to: <@&${roleName.id}>`,
 								allowedMentions: { parse: [] }
 							})
 							dbChannels.send(
-								`<@${message.author.id}> changed the adminRole in server: **${message.guild.name}**\n\`\`\`diff\n- ${found.value.roles.adminRole}\n+ ${roleName.id}\`\`\``
+								`<@${message.author.id}> changed the adminRole in server: **${message.guild.name}**\n\`\`\`diff\n- ${found.roles.adminRole}\n+ ${roleName.id}\`\`\``
 							)
 						} else if (
 							message.mentions.roles.first() &&
@@ -117,14 +117,14 @@ export default {
 							const found = await db.findOneAndUpdate(
 								{ _id: message.guild.id },
 								{ $set: { 'roles.adminRole': args[2] } },
-								{ returnOriginal: true }
+								{ returnDocument: 'before' }
 							)
 							message.channel.send({
 								content: `The Admin Role has been changed to: ${args[2]}`,
 								allowedMentions: { parse: [] }
 							})
 							dbChannels.send(
-								`<@${message.author.id}> changed the adminRole in server: **${message.guild.name}**\n\`\`\`diff\n- ${found.value.roles.adminRole}\n+ ${args[2]}\`\`\``
+								`<@${message.author.id}> changed the adminRole in server: **${message.guild.name}**\n\`\`\`diff\n- ${found.roles.adminRole}\n+ ${args[2]}\`\`\``
 							)
 						} else {
 							message.channel.send({
@@ -158,14 +158,14 @@ export default {
 							const found = await db.findOneAndUpdate(
 								{ _id: message.guild.id },
 								{ $set: { 'roles.modRole': `<@&${args[2]}>` } },
-								{ returnOriginal: true }
+								{ returnDocument: 'before' }
 							)
 							message.channel.send({
 								content: `The Mod Role has been changed to: <@&${args[2]}>`,
 								allowedMentions: { parse: [] }
 							})
 							dbChannels.send(
-								`<@${message.author.id}> changed the modRole in server: **${message.guild.name}**\n\`\`\`diff\n- ${found.value.roles.modRole}\n+ <@&${args[2]}>\`\`\``
+								`<@${message.author.id}> changed the modRole in server: **${message.guild.name}**\n\`\`\`diff\n- ${found.roles.modRole}\n+ <@&${args[2]}>\`\`\``
 							)
 						} else if (
 							roleName &&
@@ -175,14 +175,14 @@ export default {
 							const found = await db.findOneAndUpdate(
 								{ _id: message.guild.id },
 								{ $set: { 'roles.modRole': `<@&${roleName.id}>` } },
-								{ returnOriginal: true }
+								{ returnDocument: 'before' }
 							)
 							message.channel.send({
 								content: `The Mod Role has been changed to: <@&${roleName.id}>`,
 								allowedMentions: { parse: [] }
 							})
 							dbChannels.send(
-								`<@${message.author.id}> changed the modRole in server: **${message.guild.name}**\n\`\`\`diff\n- ${found.value.roles.modRole}\n+ ${roleName}\`\`\``
+								`<@${message.author.id}> changed the modRole in server: **${message.guild.name}**\n\`\`\`diff\n- ${found.roles.modRole}\n+ ${roleName}\`\`\``
 							)
 						} else if (
 							message.mentions.roles.first() &&
@@ -194,14 +194,14 @@ export default {
 							const found = await db.findOneAndUpdate(
 								{ _id: message.guild.id },
 								{ $set: { 'roles.modRole': args[2] } },
-								{ returnOriginal: true }
+								{ returnDocument: 'before' }
 							)
 							message.channel.send({
 								content: `The Mod Role has been changed to: ${args[2]}`,
 								allowedMentions: { parse: [] }
 							})
 							dbChannels.send(
-								`<@${message.author.id}> changed the modRole in server: **${message.guild.name}**\n\`\`\`diff\n- ${found.value.roles.modRole}\n+ ${args[2]}\`\`\``
+								`<@${message.author.id}> changed the modRole in server: **${message.guild.name}**\n\`\`\`diff\n- ${found.roles.modRole}\n+ ${args[2]}\`\`\``
 							)
 						} else {
 							message.channel.send({
@@ -239,26 +239,26 @@ export default {
 							const found = await db.findOneAndUpdate(
 								{ _id: message.guild.id },
 								{ $set: { 'channels.adminChannel': args[2] } },
-								{ returnOriginal: true }
+								{ returnDocument: 'before' }
 							)
 							message.channel.send({
 								content: `The Admin Channel has been set to: <#${args[2]}>`
 							})
 							dbChannels.send(
-								`<@${message.author.id}> set the Admin Channel in server: **${message.guild.name}** from <#${found.value.channels.adminChannel}> to <#${args[2]}>`
+								`<@${message.author.id}> set the Admin Channel in server: **${message.guild.name}** from <#${found.channels.adminChannel}> to <#${args[2]}>`
 							)
 						} else if (checkNum(channelTag[0], 1, Infinity) && message.guild.channels.cache.has(channelTag[0])) {
 							// Check by #Channel
 							const found = await db.findOneAndUpdate(
 								{ _id: message.guild.id },
 								{ $set: { 'channels.adminChannel': channelTag[0] } },
-								{ returnOriginal: true }
+								{ returnDocument: 'before' }
 							)
 							message.channel.send({
 								content: `The Admin Channel has been set to: <#${channelTag[0]}>`
 							})
 							dbChannels.send(
-								`<@${message.author.id}> set the Admin Channel in server: **${message.guild.name}** from <#${found.value.channels.adminChannel}> to <#${channelTag[0]}>`
+								`<@${message.author.id}> set the Admin Channel in server: **${message.guild.name}** from <#${found.channels.adminChannel}> to <#${channelTag[0]}>`
 							)
 						} else {
 							message.channel.send({
@@ -300,26 +300,26 @@ export default {
 							const found = await db.findOneAndUpdate(
 								{ _id: message.guild.id },
 								{ $set: { 'channels.events': args[2] } },
-								{ returnOriginal: true }
+								{ returnDocument: 'before' }
 							)
 							message.channel.send({
 								content: `The Events Channel has been set to: <#${args[2]}>`
 							})
 							dbChannels.send(
-								`<@${message.author.id}> set the Events Channel in server: **${message.guild.name}** from <#${found.value.channels.events}> to <#${args[2]}>`
+								`<@${message.author.id}> set the Events Channel in server: **${message.guild.name}** from <#${found.channels.events}> to <#${args[2]}>`
 							)
 						} else if (checkNum(channelTag[0], 1, Infinity) && message.guild.channels.cache.has(channelTag[0])) {
 							// Check by #Channel
 							const found = await db.findOneAndUpdate(
 								{ _id: message.guild.id },
 								{ $set: { 'channels.events': channelTag[0] } },
-								{ returnOriginal: true }
+								{ returnDocument: 'before' }
 							)
 							message.channel.send({
 								content: `The Events Channel has been set to: <#${channelTag[0]}>`
 							})
 							dbChannels.send(
-								`<@${message.author.id}> set the Events Channel in server: **${message.guild.name}** from <#${found.value.channels.events}> to <#${channelTag[0]}>`
+								`<@${message.author.id}> set the Events Channel in server: **${message.guild.name}** from <#${found.channels.events}> to <#${channelTag[0]}>`
 							)
 						} else {
 							message.channel.send({
@@ -367,26 +367,26 @@ export default {
 							const found = await db.findOneAndUpdate(
 								{ _id: message.guild.id },
 								{ $set: { 'channels.mod': args[2] } },
-								{ returnOriginal: true }
+								{ returnDocument: 'before' }
 							)
 							message.channel.send({
 								content: `The Mod Channel has been set to: <#${args[2]}>`
 							})
 							dbChannels.send(
-								`<@${message.author.id}> set the Mod Channel in server: **${message.guild.name}** from <#${found.value.channels.mod}> to <#${args[2]}>`
+								`<@${message.author.id}> set the Mod Channel in server: **${message.guild.name}** from <#${found.channels.mod}> to <#${args[2]}>`
 							)
 						} else if (checkNum(channelTag[0], 1, Infinity) && message.guild.channels.cache.has(channelTag[0])) {
 							// Check by #Channel
 							const found = await db.findOneAndUpdate(
 								{ _id: message.guild.id },
 								{ $set: { 'channels.mod': channelTag[0] } },
-								{ returnOriginal: true }
+								{ returnDocument: 'before' }
 							)
 							message.channel.send({
 								content: `The Mod Channel has been set to: <#${channelTag[0]}>`
 							})
 							dbChannels.send(
-								`<@${message.author.id}> set the Mod Channel in server: **${message.guild.name}** from <#${found.value.channels.mod}> to <#${channelTag[0]}>`
+								`<@${message.author.id}> set the Mod Channel in server: **${message.guild.name}** from <#${found.channels.mod}> to <#${channelTag[0]}>`
 							)
 						} else {
 							message.channel.send({

--- a/src/events/guild/roleDelete.js
+++ b/src/events/guild/roleDelete.js
@@ -3,10 +3,14 @@ export default async (client, role) => {
 	await db.findOne({ _id: role.guild.id }).then(async (res) => {
 		if (res.adminRole === `<@&${role.id}>`) {
 			await db
-				.findOneAndUpdate({ adminRole: `<@&${role.id}>` }, { $set: { adminRole: res.defaultAdminRole } })
+				.findOneAndUpdate(
+					{ adminRole: `<@&${role.id}>` },
+					{ $set: { adminRole: res.defaultAdminRole } },
+					{ returnDocument: 'before' }
+				)
 				.then((r) => {
 					client.users.cache.get(role.guild.ownerId).send({
-						content: `Your server Admin role was deleted in \`${role.guild.name}\` and has been set back to the default. Make sure to reset your Admin role to allow your server admins to use admin commands! Use \`${r.value.prefix}settings adminRole set <NEW ROLE>\` in ${role.guild.name} (Must have the Administrator permission)`
+						content: `Your server Admin role was deleted in \`${role.guild.name}\` and has been set back to the default. Make sure to reset your Admin role to allow your server admins to use admin commands! Use \`${r.prefix}settings adminRole set <NEW ROLE>\` in ${role.guild.name} (Must have the Administrator permission)`
 					})
 					client.channels.cache.get('731997087721586698').send({
 						content: `The Admin role **(${role.name})** in \`${role.guild.name}\` has been deleted. The server owner has been sent a message!`


### PR DESCRIPTION
## What changed

- Updated settings, fact-edit, and role-deletion flows to consume `findOneAndUpdate()` results as documents directly.
- Replaced legacy `returnOriginal: true` options with `returnDocument: 'before'`.
- Made the previous-document behavior explicit where audit messages need old values.

## Root cause

MongoDB Node.js driver 6.x returns the matched document directly by default when `includeResultMetadata` is not enabled. The existing code expected the older metadata wrapper and read fields through `result.value`, causing those paths to dereference `undefined`.

## Impact

Settings audit messages, fact edits, and deleted-admin-role notifications now use the return contract supported by both the current MongoDB 6.3 driver and the proposed 7.3 upgrade in #204. This PR can merge before or after #204.

## Validation

- `npm ci --ignore-scripts`
- `npx eslint src/commands/settings.js src/commands/fact.js src/events/guild/roleDelete.js`
- MongoDB 6.3 and 7.3 import/connection-option smoke tests on Node.js 22.14.0
- `git diff --check`
