### PR TITLE
feat(worlds): show and edit base worlds from /worlds

### DIFF
--- a/src/commands/worlds.js
+++ b/src/commands/worlds.js
@@ -3,11 +3,13 @@ import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, MessageFlag
 
 import Color from '../colors.js'
 import {
+	applyWorldsToBase,
 	applyWorldsToSpecial,
 	deriveMemberWorlds,
 	formatWorldList,
 	loadRegistry,
 	parseWorldList,
+	removeWorldsFromBase,
 	removeWorldsFromSpecial,
 	saveRegistry,
 	setSpecialEnabled,
@@ -37,7 +39,9 @@ export default {
 		'Disables a group, removing its worlds from the member worlds.',
 		"Replaces a group's worlds outright. Use this for a new league season.",
 		'Adds worlds to a group, creating the group if the key is new.',
-		'Removes worlds from a group. Other groups keep their copies of those worlds.'
+		'Removes worlds from a group. Other groups keep their copies of those worlds.',
+		'Adds permanent base worlds, e.g. a newly released world.',
+		'Removes permanent base worlds. Refuses to drop below 50.'
 	],
 	usage: [
 		'list',
@@ -46,7 +50,9 @@ export default {
 		'disable <key>',
 		'set <key> <worlds>',
 		'add <key> <worlds>',
-		'remove <key> <worlds>'
+		'remove <key> <worlds>',
+		'base add <worlds>',
+		'base remove <worlds>'
 	],
 	guildSpecific: ['668330890790699079', '420803245758480405'],
 	permissionLevel: 'Admin',
@@ -98,6 +104,23 @@ export default {
 				.setDescription('Remove worlds from a special world group.')
 				.addStringOption(keyOption)
 				.addStringOption((option) => worldsOption(option, 'e.g. 253,254'))
+		)
+		.addSubcommandGroup((group) =>
+			group
+				.setName('base')
+				.setDescription('Edit the permanent base worlds every service polls.')
+				.addSubcommand((sub) =>
+					sub
+						.setName('add')
+						.setDescription('Add permanent worlds, e.g. a newly released world.')
+						.addStringOption((option) => worldsOption(option, 'e.g. 145 or 145-147'))
+				)
+				.addSubcommand((sub) =>
+					sub
+						.setName('remove')
+						.setDescription('Remove permanent worlds, e.g. a retired world.')
+						.addStringOption((option) => worldsOption(option, 'e.g. 145'))
+				)
 		),
 	slash: async (client, interaction, perms) => {
 		if (!perms.admin) return interaction.reply(perms.errorA)
@@ -108,6 +131,36 @@ export default {
 
 		if (subcommand === 'list') return replyWithList(interaction, registry)
 		if (subcommand === 'show') return replyWithWorld(interaction, registry)
+
+		// `/worlds base add|remove` edits baseWorlds rather than a group.
+		if (interaction.options.getSubcommandGroup(false) === 'base') {
+			let baseWorlds
+			let nextBase
+			try {
+				baseWorlds = parseWorldList(interaction.options.getString('worlds'))
+				nextBase =
+					subcommand === 'add' ? applyWorldsToBase(registry, baseWorlds) : removeWorldsFromBase(registry, baseWorlds)
+			} catch (error) {
+				return interaction.reply({ content: `❌ ${error.message}`, flags: MessageFlags.Ephemeral })
+			}
+
+			const baseSummary = summariseChange(registry, nextBase, {
+				action: `base ${subcommand}`,
+				key: 'baseWorlds',
+				worlds: baseWorlds
+			})
+			if (baseSummary.blocked) {
+				return interaction.reply({ content: `❌ ${baseSummary.text}`, flags: MessageFlags.Ephemeral })
+			}
+
+			return confirmAndSave(client, interaction, {
+				collection,
+				registry: nextBase,
+				summary: baseSummary,
+				key: 'baseWorlds',
+				subcommand: `base ${subcommand}`
+			})
+		}
 
 		const key = interaction.options.getString('key')
 
@@ -165,9 +218,19 @@ export const listIcon = (special, emojiCache) => {
  * A heading is only emitted when that section has groups, so a registry with
  * everything switched on does not show an empty Disabled block.
  */
-export const buildListSections = (specials, emojiCache) => {
+export const buildListSections = (specials, emojiCache, baseWorlds = []) => {
 	const fields = []
 	let omitted = 0
+
+	// Base worlds first: they are the bulk of the member worlds and used to be
+	// invisible here, which made the counts in the description hard to check.
+	if (baseWorlds.length) {
+		fields.push({
+			name: 'Base worlds',
+			value: `${baseWorlds.length} worlds: ${formatWorldList(baseWorlds)}`.slice(0, 1024),
+			inline: false
+		})
+	}
 
 	for (const [heading, enabled] of [
 		['Enabled', true],
@@ -212,7 +275,7 @@ const replyWithList = (interaction, registry) => {
 				`and ${registry.specials.filter((special) => special.enabled).length} enabled groups.`
 		)
 
-	const fields = buildListSections(registry.specials, interaction.client?.emojis?.cache)
+	const fields = buildListSections(registry.specials, interaction.client?.emojis?.cache, registry.baseWorlds)
 	if (fields.length) embed.addFields(...fields)
 
 	if (registry.version === 0) {

--- a/src/dsf/calls/worldRegistry.js
+++ b/src/dsf/calls/worldRegistry.js
@@ -226,6 +226,38 @@ export const setSpecialWorlds = (registry, key, worlds, { label } = {}) => {
 	return next
 }
 
+/**
+ * Add worlds to the permanent base list.
+ *
+ * Base worlds are the ones that exist regardless of any seasonal group, so this
+ * is what to use when Jagex releases a world rather than when a season starts.
+ */
+export const applyWorldsToBase = (registry, worlds) => {
+	const next = cloneRegistry(registry)
+	next.baseWorlds = uniqueSorted([...next.baseWorlds, ...worlds])
+	return next
+}
+
+/**
+ * Remove worlds from the base list.
+ *
+ * Refuses to drop below MIN_BASE_WORLDS here rather than only at write time, so
+ * the command can reject it before showing a confirmation prompt. A removed
+ * world can still be a member world if an enabled special contains it.
+ */
+export const removeWorldsFromBase = (registry, worlds) => {
+	const next = cloneRegistry(registry)
+	const removing = new Set(worlds)
+	const remaining = next.baseWorlds.filter((world) => !removing.has(world))
+
+	if (remaining.length < MIN_BASE_WORLDS) {
+		throw new Error(`That would leave ${remaining.length} base worlds; there must be at least ${MIN_BASE_WORLDS}.`)
+	}
+
+	next.baseWorlds = remaining
+	return next
+}
+
 export const setSpecialEnabled = (registry, key, enabled) => {
 	const next = cloneRegistry(registry)
 	const special = findSpecial(next, key)
@@ -285,6 +317,10 @@ export const summariseChange = (before, after, { action, key, worlds = [] }) => 
 
 	const diff = diffRegistry(before, after)
 	const lines = [`**${action}** \`${key}\``, `Member worlds: ${diff.memberCountBefore} → ${diff.memberCountAfter}`]
+
+	if (before.baseWorlds.length !== after.baseWorlds.length) {
+		lines.push(`Base worlds: ${before.baseWorlds.length} → ${after.baseWorlds.length}`)
+	}
 
 	// A group's own size changing is worth reporting on its own: editing a
 	// disabled group leaves the member worlds untouched, so without this the

--- a/tests/worldRegistry.test.js
+++ b/tests/worldRegistry.test.js
@@ -6,11 +6,14 @@ import {
 	validateRegistry,
 	deriveMemberWorlds,
 	specialsForWorld,
+	applyWorldsToBase,
 	applyWorldsToSpecial,
+	removeWorldsFromBase,
 	removeWorldsFromSpecial,
 	setSpecialEnabled,
 	setSpecialWorlds,
 	diffRegistry,
+	summariseChange,
 	REGISTRY_DOCUMENT_ID,
 	MAX_ICONS_PER_WORLD
 } from '../src/dsf/calls/worldRegistry.js'
@@ -336,4 +339,81 @@ test('setSpecialWorlds sorts and deduplicates the new list', () => {
 
 test('setSpecialWorlds rejects an empty list rather than leaving an empty group', () => {
 	assert.throws(() => setSpecialWorlds(registry(), 'leagues', []), /at least one world/)
+})
+
+test('applyWorldsToBase adds worlds to the base list', () => {
+	const next = applyWorldsToBase(registry(), [300, 301])
+
+	assert.ok(next.baseWorlds.includes(300))
+	assert.ok(next.baseWorlds.includes(301))
+})
+
+test('applyWorldsToBase keeps the list sorted and deduplicated', () => {
+	const next = applyWorldsToBase(registry(), [300, 5, 300])
+
+	assert.equal(next.baseWorlds.filter((w) => w === 5).length, 1)
+	assert.deepEqual(
+		next.baseWorlds,
+		[...next.baseWorlds].sort((a, b) => a - b)
+	)
+})
+
+test('applyWorldsToBase does not mutate the input', () => {
+	const before = registry()
+	applyWorldsToBase(before, [300])
+
+	assert.ok(!before.baseWorlds.includes(300))
+})
+
+test('applyWorldsToBase leaves the specials alone', () => {
+	const next = applyWorldsToBase(registry(), [300])
+
+	assert.deepEqual(next.specials, registry().specials)
+})
+
+test('removeWorldsFromBase removes only from the base list', () => {
+	const next = removeWorldsFromBase(registry(), [5])
+
+	assert.ok(!next.baseWorlds.includes(5))
+	assert.deepEqual(next.specials, registry().specials)
+})
+
+test('removeWorldsFromBase refuses to drop below the safety floor', () => {
+	const small = registry({ baseWorlds: Array.from({ length: 51 }, (_, i) => i + 1) })
+
+	assert.throws(() => removeWorldsFromBase(small, [1, 2]), /at least 50/)
+})
+
+test('removeWorldsFromBase allows a removal that stays at the floor', () => {
+	const small = registry({ baseWorlds: Array.from({ length: 51 }, (_, i) => i + 1) })
+
+	assert.equal(removeWorldsFromBase(small, [1]).baseWorlds.length, 50)
+})
+
+test('a base world removed while still in an enabled special stays a member world', () => {
+	const before = registry({
+		specials: [{ key: 'leagues', label: 'Leagues', enabled: true, worlds: [5] }]
+	})
+	const after = removeWorldsFromBase(before, [5])
+
+	assert.ok(deriveMemberWorlds(after).includes(5))
+})
+
+test('summariseChange reports a base world addition', () => {
+	const before = registry()
+	const after = applyWorldsToBase(before, [300])
+
+	const summary = summariseChange(before, after, { action: 'base add', key: 'baseWorlds', worlds: [300] })
+
+	assert.match(summary.text, /300/)
+	assert.match(summary.text, /Base worlds: 60 → 61/)
+})
+
+test('summariseChange reports a base world removal', () => {
+	const before = registry()
+	const after = removeWorldsFromBase(before, [5])
+
+	const summary = summariseChange(before, after, { action: 'base remove', key: 'baseWorlds', worlds: [5] })
+
+	assert.match(summary.text, /Base worlds: 60 → 59/)
 })

--- a/tests/worldsListIcon.test.js
+++ b/tests/worldsListIcon.test.js
@@ -136,3 +136,37 @@ test('a single-world group is not described as "1 worlds"', () => {
 
 	assert.match(fields[1].value, /^1 world:/)
 })
+
+test('buildListSections shows a Base worlds section first', () => {
+	const fields = buildListSections([special('dsf', true)], resolver(), [1, 2, 3])
+
+	assert.equal(fields[0].name, 'Base worlds')
+	assert.match(fields[0].value, /1-3/)
+})
+
+test('the base section reports how many base worlds there are', () => {
+	const fields = buildListSections([special('dsf', true)], resolver(), [1, 2, 3])
+
+	assert.match(fields[0].value, /3 worlds/)
+})
+
+test('base worlds are collapsed into ranges like the groups', () => {
+	const base = Array.from({ length: 40 }, (_, i) => i + 1)
+	const fields = buildListSections([special('dsf', true)], resolver(), base)
+
+	assert.match(fields[0].value, /1-40/)
+	assert.ok(fields[0].value.length <= 1024)
+})
+
+test('the base section is omitted when no base worlds are passed', () => {
+	const fields = buildListSections([special('dsf', true)], resolver())
+
+	assert.ok(!fields.some((field) => field.name === 'Base worlds'))
+})
+
+test('groups still follow the base section', () => {
+	const fields = buildListSections([special('dsf', true)], resolver(), [1, 2])
+
+	assert.equal(fields[0].name, 'Base worlds')
+	assert.equal(fields[1].name, 'Enabled')
+})


### PR DESCRIPTION
## Why

`baseWorlds` is the bulk of the member world list, but it was invisible and uneditable from Discord:

- `/worlds list` showed only special groups, so the description's *"95 member worlds from 95 base worlds"* couldn't be reconciled against anything shown
- `add`/`remove`/`set` only operate on specials — adding a newly released world, or dropping a retired one, meant editing Mongo by hand

## What

**`/worlds list` gains a Base worlds section**, first, collapsed into ranges by the existing `formatWorldList()` and clamped to Discord's 1024-character field limit:

```
Base worlds
95 worlds: 1-2, 4-6, 9-10, 12, 14-16, 18, 21-28, 30-32, 35-37, ...

Enabled
🎣 DSF world (`dsf`)  1 world: 116
...
```

**`/worlds base add|remove <worlds>`** edits the permanent list — a subcommand group rather than a reserved key, so it can't be confused with editing a special named `base`, and the option descriptions can be specific ("e.g. a newly released world").

The confirmation reports the derived effect, as elsewhere:

```
**base remove** `baseWorlds`
Member worlds: 95 → 93
Base worlds: 95 → 93
Dropped from member worlds, polling stops: 1-2
```

## Safety

`removeWorldsFromBase` refuses to drop below `MIN_BASE_WORLDS` (50) **before** the prompt is shown, rather than letting the write fail later — the server re-checks the same rule on read. A base world that also sits in an enabled special stays a member world, and the summary says so instead of claiming polling stopped.

## Tests

15 new (128 total): base add/remove including immutability and the floor, the interaction with enabled specials, base-count reporting in the summary, and the new embed section — placement, range collapsing, field limit, and omission when no base worlds are passed.

## Follow-up

Server side needs nothing: `baseWorlds` was already validated and unioned there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)