### PR TITLE
refactor: rename merchChannel to eventChannel

### DIFF
--- a/scripts/renameMerchChannel.mjs
+++ b/scripts/renameMerchChannel.mjs
@@ -1,0 +1,71 @@
+/**
+ * Rename Settings.merchChannel -> Settings.eventChannel.
+ *
+ * The travelling merchant was removed from the game, so the "merch channel"
+ * name no longer describes anything. DSF-Server #85 reads `eventChannel.*` in
+ * its change stream and its global-delete path, so this migration has to land
+ * before that server change deploys — otherwise Discord calls stop reaching the
+ * server and global deletes raise KeyError.
+ *
+ * Only the Settings collection is affected: two guild documents. Scouter
+ * profiles (ScoutTracker) are untouched — their merchant counts are history and
+ * are deliberately kept.
+ *
+ * Usage:
+ *   node scripts/renameMerchChannel.mjs                      # dry run, all guilds
+ *   node scripts/renameMerchChannel.mjs --guild 6683...      # dry run, one guild
+ *   node scripts/renameMerchChannel.mjs --guild 6683... --apply
+ *   node scripts/renameMerchChannel.mjs --rollback --apply   # eventChannel -> merchChannel
+ */
+import pkg from 'mongodb'
+import dotenv from 'dotenv'
+
+dotenv.config()
+const { MongoClient } = pkg
+
+const args = process.argv.slice(2)
+const apply = args.includes('--apply')
+const rollback = args.includes('--rollback')
+const guildIndex = args.indexOf('--guild')
+const guild = guildIndex === -1 ? null : args[guildIndex + 1]
+
+const from = rollback ? 'eventChannel' : 'merchChannel'
+const to = rollback ? 'merchChannel' : 'eventChannel'
+
+const client = new MongoClient(process.env.DB_URI, { compressors: ['snappy'] })
+
+try {
+	await client.connect()
+	const settings = client.db('Members').collection('Settings')
+
+	const filter = { [from]: { $exists: true }, ...(guild ? { _id: guild } : {}) }
+	const matches = await settings.find(filter, { projection: { _id: 1, [from]: 1 } }).toArray()
+
+	console.log(`${apply ? 'APPLYING' : 'DRY RUN'}: ${from} -> ${to}${guild ? ` for guild ${guild}` : ' (all guilds)'}`)
+	if (!matches.length) {
+		console.log('No documents to migrate. Nothing to do.')
+		process.exit(0)
+	}
+
+	for (const doc of matches) {
+		const keys = Object.keys(doc[from] ?? {})
+		console.log(`  ${doc._id}: ${from} -> ${to}  (subkeys: ${keys.join(', ')})`)
+
+		// Refuse to clobber: if the target already exists the two would merge
+		// unpredictably, so that document needs looking at by hand.
+		const existing = await settings.findOne({ _id: doc._id, [to]: { $exists: true } }, { projection: { _id: 1 } })
+		if (existing) {
+			console.log(`  ✗ ${doc._id} already has ${to}; skipping so nothing is overwritten.`)
+			continue
+		}
+
+		if (!apply) continue
+
+		const result = await settings.updateOne({ _id: doc._id }, { $rename: { [from]: to } })
+		console.log(`  ✔ ${doc._id}: matched ${result.matchedCount}, modified ${result.modifiedCount}`)
+	}
+
+	if (!apply) console.log('\nDry run only. Re-run with --apply to write.')
+} finally {
+	await client.close()
+}

--- a/src/commands/dsf.js
+++ b/src/commands/dsf.js
@@ -43,10 +43,10 @@ export default {
 					default:
 						try {
 							const {
-								merchChannel: { otherMessages, otherChannelID }
+								eventChannel: { otherMessages, otherChannelID }
 							} = await db.findOne(
 								{ _id: message.guild.id },
-								{ projection: { 'merchChannel.otherMessages': 1, 'merchChannel.otherChannelID': 1 } }
+								{ projection: { 'eventChannel.otherMessages': 1, 'eventChannel.otherChannelID': 1 } }
 							)
 							const fields = []
 							const embed = nEmbed(
@@ -86,7 +86,7 @@ export default {
 							{ _id: message.guild.id },
 							{
 								$pull: {
-									'merchChannel.otherMessages': { time: { $gt: 0 } }
+									'eventChannel.otherMessages': { time: { $gt: 0 } }
 								}
 							}
 						)

--- a/src/dsf/calls/counts.js
+++ b/src/dsf/calls/counts.js
@@ -10,14 +10,14 @@ export const addCount = async (client, message, alt1Count = false) => {
 	try {
 		// Get fields from database
 		const {
-			merchChannel: { otherChannelID, otherMessages },
+			eventChannel: { otherChannelID, otherMessages },
 			disallowedWords
 		} = await db.findOne(
 			{ _id: message.guild.id },
 			{
 				projection: {
-					'merchChannel.otherChannelID': 1,
-					'merchChannel.otherMessages': 1,
+					'eventChannel.otherChannelID': 1,
+					'eventChannel.otherMessages': 1,
 					disallowedWords: 1
 				}
 			}
@@ -151,7 +151,7 @@ export const addCount = async (client, message, alt1Count = false) => {
 
 export const addMessageToDB = async (message, db, eventID) => {
 	const addMessageData = {
-		'merchChannel.otherMessages': {
+		'eventChannel.otherMessages': {
 			eventID: eventID,
 			messageID: message.id,
 			content: message.content,

--- a/src/dsf/calls/main.js
+++ b/src/dsf/calls/main.js
@@ -7,13 +7,13 @@ const dsf = async (client, message) => {
 	const db = client.database.settings
 	const channels = await client.database.channels
 	const {
-		merchChannel: { otherChannelID, otherMessages }
+		eventChannel: { otherChannelID, otherMessages }
 	} = await db.findOne(
-		{ _id: message.guild.id, merchChannel: { $exists: true } },
+		{ _id: message.guild.id, eventChannel: { $exists: true } },
 		{
 			projection: {
-				'merchChannel.otherChannelID': 1,
-				'merchChannel.otherMessages': 1
+				'eventChannel.otherChannelID': 1,
+				'eventChannel.otherMessages': 1
 			}
 		}
 	)

--- a/src/dsf/calls/skullTimer.js
+++ b/src/dsf/calls/skullTimer.js
@@ -49,7 +49,7 @@ export const skullTimer = async (client, message, channel = 'other') => {
 		}
 		channels.errors.send(err)
 	} finally {
-		await db.updateOne({ _id: message.guild.id }, { $pull: { 'merchChannel.otherMessages': { messageID } } })
+		await db.updateOne({ _id: message.guild.id }, { $pull: { 'eventChannel.otherMessages': { messageID } } })
 	}
 }
 
@@ -73,8 +73,8 @@ export const mistyEventTimer = (content) => {
 }
 
 export const removeReactPermissions = async (message, allMessages) => {
-	const merchChannel = message.channel
-	const channelPermissions = merchChannel.permissionOverwrites.cache.get(message.author.id)
+	const eventChannel = message.channel
+	const channelPermissions = eventChannel.permissionOverwrites.cache.get(message.author.id)
 
 	if (channelPermissions) {
 		const moreThanOnce = allMessages.filter((obj) => obj.userID === message.author.id && obj.messageID !== message.id)
@@ -86,8 +86,8 @@ export const removeReactPermissions = async (message, allMessages) => {
 
 export const startupRemoveReactionPermissions = async (client, db) => {
 	const {
-		merchChannel: { otherMessages, otherChannelID }
-	} = await db.findOne({ _id: '420803245758480405' }, { projection: { merchChannel: { otherMessages: 1, otherChannelID: 1 } } })
+		eventChannel: { otherMessages, otherChannelID }
+	} = await db.findOne({ _id: '420803245758480405' }, { projection: { eventChannel: { otherMessages: 1, otherChannelID: 1 } } })
 
 	const channelObj = client.channels.cache.get(otherChannelID)
 
@@ -106,7 +106,7 @@ export const startupRemoveReactionPermissions = async (client, db) => {
 				{ _id: '420803245758480405' },
 				{
 					$pull: {
-						'merchChannel.otherMessages': { messageID: unwrappedMessageObj.messageID }
+						'eventChannel.otherMessages': { messageID: unwrappedMessageObj.messageID }
 					}
 				}
 			)

--- a/src/events/client/ready.js
+++ b/src/events/client/ready.js
@@ -61,13 +61,13 @@ export default async (client) => {
 	const guild = client.guilds.cache.get(guildId)
 
 	const {
-		merchChannel: { otherChannelID, otherMessages }
+		eventChannel: { otherChannelID, otherMessages }
 	} = await db.findOne(
-		{ _id: guildId, merchChannel: { $exists: true } },
+		{ _id: guildId, eventChannel: { $exists: true } },
 		{
 			projection: {
-				'merchChannel.otherChannelID': 1,
-				'merchChannel.otherMessages': 1
+				'eventChannel.otherChannelID': 1,
+				'eventChannel.otherMessages': 1
 			}
 		}
 	)
@@ -95,7 +95,7 @@ export default async (client) => {
 			if (err?.code === 10008) {
 				await db.updateOne(
 					{ _id: guildId },
-					{ $pull: { 'merchChannel.otherMessages': { messageID: eventMsg.messageID } } }
+					{ $pull: { 'eventChannel.otherMessages': { messageID: eventMsg.messageID } } }
 				)
 				continue
 			}

--- a/src/events/guild/interactionCreate.js
+++ b/src/events/guild/interactionCreate.js
@@ -7,7 +7,7 @@ export default async (client, interaction) => {
 	const db = client.database.settings
 	const data = await db.findOne(
 		{ _id: interaction.guildId },
-		{ projection: { merchChannel: { components: 1, otherChannelID: 1, deletions: 1 } } }
+		{ projection: { eventChannel: { components: 1, otherChannelID: 1, deletions: 1 } } }
 	)
 
 	try {

--- a/src/events/guild/messageCreate.js
+++ b/src/events/guild/messageCreate.js
@@ -38,10 +38,10 @@ export default async (client, message) => {
 	// Deep Sea Fishing
 	if (message.guild.id === '420803245758480405' || message.guild.id === '668330890790699079') {
 		const {
-			merchChannel: { otherChannelID }
+			eventChannel: { otherChannelID }
 		} = await db.findOne(
-			{ _id: message.guild.id, merchChannel: { $exists: true } },
-			{ projection: { 'merchChannel.otherChannelID': 1 } }
+			{ _id: message.guild.id, eventChannel: { $exists: true } },
+			{ projection: { 'eventChannel.otherChannelID': 1 } }
 		)
 
 		if (message.channel.parent) {

--- a/src/events/guild/messageDelete.js
+++ b/src/events/guild/messageDelete.js
@@ -27,16 +27,16 @@ export default async (client, message) => {
 	}
 
 	const fullDB = await db.findOne(
-		{ _id: message.guild.id, merchChannel: { $exists: true } },
-		{ projection: { merchChannel: { otherMessages: 1, otherChannelID: 1 } } }
+		{ _id: message.guild.id, eventChannel: { $exists: true } },
+		{ projection: { eventChannel: { otherMessages: 1, otherChannelID: 1 } } }
 	)
 	if (!fullDB) {
-		client.logger.debug(`messageDelete early return: no merchChannel data for guild=${message.guild.id}`)
+		client.logger.debug(`messageDelete early return: no eventChannel data for guild=${message.guild.id}`)
 		return
 	}
-	const otherChannelID = message.guild.channels.cache.get(fullDB.merchChannel.otherChannelID)
+	const otherChannelID = message.guild.channels.cache.get(fullDB.eventChannel.otherChannelID)
 	client.logger.debug(
-		`messageDelete channel check: deletedChannel=${message.channel?.id} configuredOther=${fullDB.merchChannel.otherChannelID} resolvedOther=${otherChannelID?.id}`
+		`messageDelete channel check: deletedChannel=${message.channel?.id} configuredOther=${fullDB.eventChannel.otherChannelID} resolvedOther=${otherChannelID?.id}`
 	)
 
 	const botServerChannel = client.channels.cache.get('784543962174062608') ?? message.channel
@@ -63,10 +63,10 @@ export default async (client, message) => {
 				{ _id: message.guild.id },
 				{
 					$pull: {
-						'merchChannel.otherMessages': { messageID: data.messageID }
+						'eventChannel.otherMessages': { messageID: data.messageID }
 					},
 					$addToSet: {
-						'merchChannel.deletions.messages': { messageID: sentChannel.id, authorID: userID, eventID: data.eventID }
+						'eventChannel.deletions.messages': { messageID: sentChannel.id, authorID: userID, eventID: data.eventID }
 					}
 				}
 			)
@@ -106,7 +106,7 @@ export default async (client, message) => {
 	}
 
 	const handleDeletions = async (deletedBy = null) => {
-		const checkDB = fullDB.merchChannel.otherMessages.find((entry) => entry.messageID === message.id)
+		const checkDB = fullDB.eventChannel.otherMessages.find((entry) => entry.messageID === message.id)
 		const button = buttonSelectionOther
 		client.logger.debug(`messageDelete DB lookup: found=${Boolean(checkDB)} deletedBy=${deletedBy ?? 'author'}`)
 

--- a/src/handlers/interactions/buttons.js
+++ b/src/handlers/interactions/buttons.js
@@ -230,7 +230,7 @@ export const buttons = async (client, interaction, data, cache) => {
 					timestamp = timestamp.split(' ').slice(2).join(' ').slice(0, -3)
 					const serverName = interaction.member.guild.name
 					const potentialPassowrd = content.split(' ').slice(2).join(' ')
-					const passwordDM = `${serverName}\n\nHello.\n\nWe saw you typed into the <#${data.merchChannel.otherChannelID}> channel on ${timestamp} and the Deep Sea Fishing Admins have flagged this as a potential password which is why you are receiving this DM. That specific channel has all messages logged.\n\nYour message content: ${potentialPassowrd}\n\nIf it is a password, then we recommend that you change it ASAP, even though it got deleted straight away. Please respond with one of the selections to let our Admins know if we should also delete that message from our message logs.\n\nDSF Admin Team.`
+					const passwordDM = `${serverName}\n\nHello.\n\nWe saw you typed into the <#${data.eventChannel.otherChannelID}> channel on ${timestamp} and the Deep Sea Fishing Admins have flagged this as a potential password which is why you are receiving this DM. That specific channel has all messages logged.\n\nYour message content: ${potentialPassowrd}\n\nIf it is a password, then we recommend that you change it ASAP, even though it got deleted straight away. Please respond with one of the selections to let our Admins know if we should also delete that message from our message logs.\n\nDSF Admin Team.`
 
 					try {
 						await guildMember.send({ content: passwordDM, components: [menu] })
@@ -268,7 +268,7 @@ export const buttons = async (client, interaction, data, cache) => {
 				break
 			case 'Show How To React':
 				{
-					const reactMessage = `<@!${userId}> Right Click / Long Press the Message > Apps > Mark event as dead.\nFor more information, check the pins in <#${data.merchChannel.otherChannelID}>.`
+					const reactMessage = `<@!${userId}> Right Click / Long Press the Message > Apps > Mark event as dead.\nFor more information, check the pins in <#${data.eventChannel.otherChannelID}>.`
 
 					await generalChannel.send({ content: reactMessage })
 					await interaction.update({ components: [] })
@@ -279,7 +279,7 @@ export const buttons = async (client, interaction, data, cache) => {
 				{
 					const welcomeChannel = interaction.guild.channels.cache.find((c) => c.name === 'welcome')
 					const welcomeRef = welcomeChannel ? `<#${welcomeChannel.id}>` : '`#welcome`'
-					const nonsenseMessage = `<@!${userId}>, <#${data.merchChannel.otherChannelID}> is for calls only. Please read ${welcomeRef} and ${rulesRef}.`
+					const nonsenseMessage = `<@!${userId}>, <#${data.eventChannel.otherChannelID}> is for calls only. Please read ${welcomeRef} and ${rulesRef}.`
 
 					await generalChannel.send({ content: nonsenseMessage })
 					await interaction.update({ components: [] })
@@ -309,7 +309,7 @@ export const buttons = async (client, interaction, data, cache) => {
 			case 'Remove Other Count':
 				{
 					if (interaction.user.bot) return
-					const item = data.merchChannel.deletions.messages.find((item) => item.messageID === interaction.message.id)
+					const item = data.eventChannel.deletions.messages.find((item) => item.messageID === interaction.message.id)
 					if (item) {
 						await scouters.updateOne(
 							{ userID: item.authorID },
@@ -323,7 +323,7 @@ export const buttons = async (client, interaction, data, cache) => {
 							{ _id: interaction.guild.id },
 							{
 								$pull: {
-									'merchChannel.deletions.messages': { messageID: item.messageID }
+									'eventChannel.deletions.messages': { messageID: item.messageID }
 								}
 							}
 						)
@@ -532,7 +532,7 @@ export const buttons = async (client, interaction, data, cache) => {
 				break
 			case 'Read The Pins':
 				await generalChannel.send({
-					content: `<@!${userId}>, invalid call format. Read the pins in <#${data.merchChannel.otherChannelID}> for acceptable formats!`
+					content: `<@!${userId}>, invalid call format. Read the pins in <#${data.eventChannel.otherChannelID}> for acceptable formats!`
 				})
 				await interaction.update({ components: [] })
 				await buttonLogger.upload(userId)
@@ -548,7 +548,7 @@ export const buttons = async (client, interaction, data, cache) => {
 				await generalChannel.send({
 					content: `<@${userId}>, thanks for the call but world \`${getWorldNumber(
 						content
-					)}\` has already been posted! <#${data.merchChannel.otherChannelID}>`
+					)}\` has already been posted! <#${data.eventChannel.otherChannelID}>`
 				})
 				await interaction.update({ components: [] })
 				break

--- a/src/handlers/interactions/commands.js
+++ b/src/handlers/interactions/commands.js
@@ -32,7 +32,7 @@ export const commands = async (client, interaction, data) => {
 	}
 
 	try {
-		if (interaction.guildId === '420803245758480405' && interaction.channel.id === data.merchChannel.otherChannelID) {
+		if (interaction.guildId === '420803245758480405' && interaction.channel.id === data.eventChannel.otherChannelID) {
 			return interaction.reply({ content: 'Please use the bot commands channel.', flags: MessageFlags.Ephemeral })
 		} else {
 			await command.slash(client, interaction, perms)

--- a/src/handlers/interactions/contextMenu.js
+++ b/src/handlers/interactions/contextMenu.js
@@ -5,7 +5,7 @@ export const contextMenu = async (client, interaction, data) => {
 	const dsfServerErrorChannel = client.channels.cache.get('884076361940078682')
 	switch (interaction.commandName) {
 		case 'Mark event as dead.':
-			if (interaction.channel.id === data.merchChannel.otherChannelID) {
+			if (interaction.channel.id === data.eventChannel.otherChannelID) {
 				try {
 					const message = await interaction.channel.messages.fetch(interaction.targetId)
 					// 1st safeguard to check the cache.


### PR DESCRIPTION
## Why

The travelling merchant was removed from the game, so `merchChannel` no longer describes what that document holds — it's where all event calls live.

**This must land before DSF-Server #85 deploys.** That PR reads `eventChannel.*` in its change stream (`^eventChannel\.(?:messages|otherMessages|deletions\.messages)\.\d+$`) and in the global-delete path (`server["eventChannel"]["otherMessages"]`). Against today's `merchChannel` documents that means:

- Discord calls silently stop reaching the server — the regex never matches
- every global delete raises `KeyError`

## What

- **43 references across 11 files** renamed `merchChannel` → `eventChannel`
- **`scripts/renameMerchChannel.mjs`** migrates the two Settings documents (`668330890790699079`, `420803245758480405` — verified against the live DB; no other collection carries the field)

The script is dry-run by default:

```bash
node scripts/renameMerchChannel.mjs                              # dry run, all guilds
node scripts/renameMerchChannel.mjs --guild 668330890790699079   # dry run, one guild
node scripts/renameMerchChannel.mjs --guild 668330890790699079 --apply
node scripts/renameMerchChannel.mjs --rollback --apply           # reverse it
```

It refuses to write when the target field already exists, so a half-run migration can't merge two subtrees.

## Scouter profiles are untouched

Merchant counts are history and are deliberately kept. **2453 profiles** carry them (`count`, `alt1.merchantCount`, `alt1First.merchantCount`) and this PR does not read or write any of them. The bot already treats them as legacy-only — *"Merchant count is legacy-only and can no longer be adjusted"* — so the remaining "Merch count:" strings are historical displays and stay.

## Deploy order

1. Merge this PR (bot code now expects `eventChannel`)
2. Run the migration — test guild first, verify, then DSF
3. Merge DSF-Server #85

Between 1 and 2 there's a short window where the bot reads `eventChannel` from documents that still say `merchChannel`; event-call features no-op during it, so run the migration right after the deploy completes.

## Tests

128 pass. The rename is mechanical (`merchChannel` is a distinct token — `merchantCount` and friends are untouched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)