### PR TITLE
chore: run prettier from package.json instead of the archived mirror

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,10 +7,16 @@ repos:
     -   id: check-merge-conflict
     -   id: mixed-line-ending
         args: [--fix=lf]
--   repo: https://github.com/pre-commit/mirrors-prettier
-    rev: "v4.0.0-alpha.8"
+# Runs the prettier pinned in package.json rather than a mirrored copy:
+# mirrors-prettier is archived and its last release is a 4.0 alpha, which
+# formats differently from the 3.x this repo installs. Two versions meant CI
+# and a local `npx prettier` disagreed about the same files.
+-   repo: local
     hooks:
     -   id: prettier
+        name: prettier
+        entry: node node_modules/prettier/bin/prettier.cjs --write
+        language: system
         types: [javascript]
 -   repo: https://github.com/pre-commit/mirrors-eslint
     rev: 'v10.8.1'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "start": "node ./src/index.js",
     "slash": "cross-env NODE_ENV=DEV node ./src/slashCommands.js",
     "dev": "cross-env NODE_ENV=DEV node ./src/index.js",
-    "test": "node --test \"tests/*.test.js\""
+    "test": "node --test \"tests/*.test.js\"",
+    "format": "prettier --write \"src/**/*.js\" \"tests/**/*.js\"",
+    "format:check": "prettier --check \"src/**/*.js\" \"tests/**/*.js\""
   },
   "author": "Luke",
   "license": "ISC",


### PR DESCRIPTION
## Why

CI and a local prettier run disagreed about the same files:

| | Version |
|---|---|
| pre-commit hook | `mirrors-prettier` @ **v4.0.0-alpha.8** |
| `package.json` | prettier **3.9.6** |

They format differently. The alpha rewrote three files (`self-assign.js`, `settings.js`, `counts.js`) that the pinned version considers already correct — so any commit touching anything reformatted them, and `npx prettier --check` then complained about the result. That's what tripped up #248.

`mirrors-prettier` is archived upstream and that alpha is its final release, so pinning to it means tracking an abandoned pre-release. Installing the alpha locally is worse: it nests a copy of 3.9.6 inside itself and its `.bin` shim reports `3.9.6`, so the two versions can't even be told apart from the command line.

## What

- The pre-commit hook is now a `local` hook running the prettier this repo installs, so `package.json` is the single source of truth for the version
- Adds `format` and `format:check` scripts, matching DSF-Event-Tracker
- The hook invokes prettier through `node node_modules/prettier/bin/prettier.cjs` rather than the `.bin` shim, whose exec bit doesn't reliably survive a reinstall

CI already runs `npm ci` before `pre-commit run --all-files` in `lint.yml`, so prettier is installed by the time the hook fires.

## Verification

`pre-commit run --all-files` passes **twice in a row** (the earlier setup did not converge), `npm run format:check` is clean, and the 128 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)