### PR TITLE
fix: stop missing guild settings from crashing the bot

### DIFF
--- a/src/commands/dsf.js
+++ b/src/commands/dsf.js
@@ -43,11 +43,12 @@ export default {
 					default:
 						try {
 							const {
-								eventChannel: { otherMessages, otherChannelID }
-							} = await db.findOne(
-								{ _id: message.guild.id },
-								{ projection: { 'eventChannel.otherMessages': 1, 'eventChannel.otherChannelID': 1 } }
-							)
+								eventChannel: { otherMessages, otherChannelID } = { otherMessages: [], otherChannelID: null }
+							} =
+								(await db.findOne(
+									{ _id: message.guild.id },
+									{ projection: { 'eventChannel.otherMessages': 1, 'eventChannel.otherChannelID': 1 } }
+								)) ?? {}
 							const fields = []
 							const embed = nEmbed(
 								'List of messages currently stored in the DB',

--- a/src/dsf/calls/counts.js
+++ b/src/dsf/calls/counts.js
@@ -9,19 +9,17 @@ export const addCount = async (client, message, alt1Count = false) => {
 
 	try {
 		// Get fields from database
-		const {
-			eventChannel: { otherChannelID, otherMessages },
-			disallowedWords
-		} = await db.findOne(
-			{ _id: message.guild.id },
-			{
-				projection: {
-					'eventChannel.otherChannelID': 1,
-					'eventChannel.otherMessages': 1,
-					disallowedWords: 1
+		const { eventChannel: { otherChannelID, otherMessages } = { otherChannelID: null, otherMessages: [] }, disallowedWords } =
+			(await db.findOne(
+				{ _id: message.guild.id },
+				{
+					projection: {
+						'eventChannel.otherChannelID': 1,
+						'eventChannel.otherMessages': 1,
+						disallowedWords: 1
+					}
 				}
-			}
-		)
+			)) ?? {}
 
 		const callChannel = client.channels.cache.get(otherChannelID)
 		const callRegex = OTHER_CALLS_REGEX

--- a/src/dsf/calls/main.js
+++ b/src/dsf/calls/main.js
@@ -1,3 +1,4 @@
+import { getEventChannel } from './settingsAccess.js'
 import { mistyEventTimer, addCount, addMessageToDB, getWorldNumber, worldReaction, WORLD_FULL_MESSAGE } from '../index.js'
 import { startEventTimer } from './eventTimers.js'
 import { v4 as uuid } from 'uuid'
@@ -6,17 +7,8 @@ import axios from 'axios'
 const dsf = async (client, message) => {
 	const db = client.database.settings
 	const channels = await client.database.channels
-	const {
-		eventChannel: { otherChannelID, otherMessages }
-	} = await db.findOne(
-		{ _id: message.guild.id, eventChannel: { $exists: true } },
-		{
-			projection: {
-				'eventChannel.otherChannelID': 1,
-				'eventChannel.otherMessages': 1
-			}
-		}
-	)
+	const { otherChannelID, otherMessages, found } = await getEventChannel(db, message.guild.id)
+	if (!found) return
 
 	const comeViaWebhook = message.author.username === 'Alt1 Tracker'
 	if (message.author.bot && !comeViaWebhook) return

--- a/src/dsf/calls/settingsAccess.js
+++ b/src/dsf/calls/settingsAccess.js
@@ -1,0 +1,52 @@
+import { logger } from '../../logging.js'
+
+/**
+ * Safe reads of the guild settings document.
+ *
+ * Several places destructured `eventChannel` straight out of a findOne result:
+ *
+ *     const { eventChannel: { otherChannelID, otherMessages } } = await db.findOne(...)
+ *
+ * That throws when the document is missing, when the field is missing, or when
+ * Mongo is unreachable — and in `ready.js` it threw during client startup, which
+ * emits an unhandled 'error' on the Discord client and exits the process. The
+ * bot crash-looped through the merchChannel -> eventChannel migration for
+ * exactly this reason: new code, documents not yet renamed.
+ *
+ * Missing settings are a normal state (a fresh guild, a half-finished
+ * migration), so they should degrade rather than take the process down.
+ */
+
+/**
+ * The event channel settings for a guild, with empty defaults.
+ *
+ * Returns `{ otherChannelID, otherMessages, found }`. `found` is false when
+ * there was nothing usable to read, so callers can skip work instead of acting
+ * on empty values.
+ */
+export const getEventChannel = async (collection, guildId) => {
+	const empty = { otherChannelID: null, otherMessages: [], found: false }
+
+	let document
+	try {
+		document = await collection.findOne(
+			{ _id: guildId },
+			{ projection: { 'eventChannel.otherChannelID': 1, 'eventChannel.otherMessages': 1 } }
+		)
+	} catch (error) {
+		logger.error(`Could not read event channel settings for ${guildId}: ${error.message}`)
+		return empty
+	}
+
+	const eventChannel = document?.eventChannel
+	if (!eventChannel) {
+		logger.warn(`No eventChannel settings for guild ${guildId}; skipping event channel work.`)
+		return empty
+	}
+
+	return {
+		otherChannelID: eventChannel.otherChannelID ?? null,
+		otherMessages: eventChannel.otherMessages ?? [],
+		found: true
+	}
+}

--- a/src/dsf/calls/skullTimer.js
+++ b/src/dsf/calls/skullTimer.js
@@ -1,3 +1,4 @@
+import { getEventChannel } from './settingsAccess.js'
 import timers from 'timers/promises'
 import { logger } from '../../logging.js'
 import { TEN_MINUTES, ALL_EVENTS_REGEX } from './constants.js'
@@ -85,9 +86,8 @@ export const removeReactPermissions = async (message, allMessages) => {
 }
 
 export const startupRemoveReactionPermissions = async (client, db) => {
-	const {
-		eventChannel: { otherMessages, otherChannelID }
-	} = await db.findOne({ _id: '420803245758480405' }, { projection: { eventChannel: { otherMessages: 1, otherChannelID: 1 } } })
+	const { otherMessages, otherChannelID, found } = await getEventChannel(db, '420803245758480405')
+	if (!found) return
 
 	const channelObj = client.channels.cache.get(otherChannelID)
 

--- a/src/events/client/ready.js
+++ b/src/events/client/ready.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-octal */
+import { getEventChannel } from '../../dsf/calls/settingsAccess.js'
 import { updateAllMemberDataBaseRankRoles } from '../../alt1.js'
 import {
 	scout,
@@ -60,17 +61,10 @@ export default async (client) => {
 	const guildId = process.env.NODE_ENV === 'DEV' ? '668330890790699079' : '420803245758480405'
 	const guild = client.guilds.cache.get(guildId)
 
-	const {
-		eventChannel: { otherChannelID, otherMessages }
-	} = await db.findOne(
-		{ _id: guildId, eventChannel: { $exists: true } },
-		{
-			projection: {
-				'eventChannel.otherChannelID': 1,
-				'eventChannel.otherMessages': 1
-			}
-		}
-	)
+	// No early return: startup continues to setPresence and the cron schedules
+	// below even when a guild has no event channel configured. otherMessages
+	// defaults to [], so the restore loop simply has nothing to do.
+	const { otherChannelID, otherMessages } = await getEventChannel(db, guildId)
 
 	for (const eventMsg of otherMessages) {
 		let durationMs = 0

--- a/src/events/guild/messageCreate.js
+++ b/src/events/guild/messageCreate.js
@@ -1,3 +1,4 @@
+import { getEventChannel } from '../../dsf/calls/settingsAccess.js'
 import Color from '../../colors.js'
 import { Permissions } from '../../classes.js'
 import { EmbedBuilder, ChannelType } from 'discord.js'
@@ -37,12 +38,10 @@ export default async (client, message) => {
 
 	// Deep Sea Fishing
 	if (message.guild.id === '420803245758480405' || message.guild.id === '668330890790699079') {
-		const {
-			eventChannel: { otherChannelID }
-		} = await db.findOne(
-			{ _id: message.guild.id, eventChannel: { $exists: true } },
-			{ projection: { 'eventChannel.otherChannelID': 1 } }
-		)
+		// No early return: this branch also handles forum posts and replies that
+		// have nothing to do with the event channel. A null otherChannelID simply
+		// never matches the `case otherChannelID` below.
+		const { otherChannelID } = await getEventChannel(db, message.guild.id)
 
 		if (message.channel.parent) {
 			if (message.channel.parent.type === ChannelType.GuildForum) {

--- a/tests/settingsAccess.test.js
+++ b/tests/settingsAccess.test.js
@@ -1,0 +1,80 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { getEventChannel } from '../src/dsf/calls/settingsAccess.js'
+
+const collection = (document) => ({ findOne: async () => document })
+
+test('returns the channel fields when the document is complete', async () => {
+	const result = await getEventChannel(
+		collection({ eventChannel: { otherChannelID: '123', otherMessages: [{ messageID: '1' }] } }),
+		'420803245758480405'
+	)
+
+	assert.equal(result.otherChannelID, '123')
+	assert.equal(result.otherMessages.length, 1)
+})
+
+test('returns empty defaults when the document is missing', async () => {
+	const result = await getEventChannel(collection(null), '420803245758480405')
+
+	assert.equal(result.otherChannelID, null)
+	assert.deepEqual(result.otherMessages, [])
+})
+
+test('returns empty defaults when eventChannel is absent', async () => {
+	const result = await getEventChannel(collection({ _id: 'x' }), '420803245758480405')
+
+	assert.equal(result.otherChannelID, null)
+	assert.deepEqual(result.otherMessages, [])
+})
+
+test('does not throw when the document is missing', async () => {
+	await assert.doesNotReject(() => getEventChannel(collection(null), 'x'))
+})
+
+test('does not throw when eventChannel is absent', async () => {
+	await assert.doesNotReject(() => getEventChannel(collection({ _id: 'x' }), 'x'))
+})
+
+test('survives the database call failing', async () => {
+	const failing = {
+		findOne: async () => {
+			throw new Error('mongo is down')
+		}
+	}
+
+	const result = await getEventChannel(failing, 'x')
+
+	assert.equal(result.otherChannelID, null)
+	assert.deepEqual(result.otherMessages, [])
+})
+
+test('reports whether the settings were found, so callers can skip work', async () => {
+	const found = await getEventChannel(collection({ eventChannel: { otherChannelID: '1', otherMessages: [] } }), 'x')
+	const missing = await getEventChannel(collection(null), 'x')
+
+	assert.equal(found.found, true)
+	assert.equal(missing.found, false)
+})
+
+test('defaults otherMessages when only the channel id is stored', async () => {
+	const result = await getEventChannel(collection({ eventChannel: { otherChannelID: '123' } }), 'x')
+
+	assert.equal(result.otherChannelID, '123')
+	assert.deepEqual(result.otherMessages, [])
+})
+
+test('queries the guild it was asked for', async () => {
+	let seen
+	const spy = {
+		findOne: async (query) => {
+			seen = query
+			return { eventChannel: {} }
+		}
+	}
+
+	await getEventChannel(spy, '668330890790699079')
+
+	assert.equal(seen._id, '668330890790699079')
+})


### PR DESCRIPTION
## Why

Tonight's `merchChannel` → `eventChannel` migration took the production bot down for ~2 minutes. Not because the rename was wrong, but because this pattern is fatal:

```js
const { eventChannel: { otherChannelID, otherMessages } } = await db.findOne(...)
```

```
TypeError: Cannot destructure property 'eventChannel' of '(intermediate value)' as it is null.
    at src/events/client/ready.js:64:17
```

In `ready.js` that throw happens during client startup, which emits an unhandled `'error'` on the Discord client and **exits the process** — so the container crash-looped until the documents were renamed. It throws for a missing document, a missing field, *or* an unreachable Mongo.

Missing settings are a normal state — a guild that hasn't configured a channel, a half-finished migration — and should degrade rather than kill the bot.

## What

`getEventChannel(collection, guildId)` returns `{ otherChannelID, otherMessages, found }` with empty defaults, logs why it came up empty, and survives the query throwing. Applied at the four sites reading those fields, replacing four copies of the same query.

**Where each caller resumes differs, so the guards deliberately aren't uniform:**

| Site | Behaviour | Why |
|---|---|---|
| `ready.js` | no early return | startup continues to `setPresence` and three cron schedules; `otherMessages` defaults to `[]` so the restore loop no-ops |
| `messageCreate.js` | no early return | that branch also handles forum posts and replies; a null `otherChannelID` never matches the `case otherChannelID` below |
| `main.js` | returns | everything after depends on the channel |
| `skullTimer.js` | returns | same |

An early return in `ready.js` would have been the obvious fix and would have silently disabled the daily fact post, the DSF activity posts and the presence — worse than the crash it replaced.

`counts.js` and `dsf.js` read the same shape inside `try/catch`, so they can't kill the process; they get destructuring defaults instead of an exception swallowed into the errors channel. `messageDelete.js` already guarded correctly and is untouched.

## Tests

9 new (137 total): complete document, missing document, missing field, partial field, query failure, the `found` flag, and that the right guild is queried.

🤖 Generated with [Claude Code](https://claude.com/claude-code)