### PR TITLE
fix(scouts): ignore departed members in the weekly scouter embed

### DIFF
--- a/src/DataBase.js
+++ b/src/DataBase.js
@@ -87,9 +87,11 @@ export class MongoDataBase {
 				},
 				dsfOwners: {
 					id: '781145730710503434',
-					send: function (content) {
+					// Takes `rest` like logs.send: without it a caller passing
+					// { files: [...] } would have its attachment silently dropped.
+					send: function (content, rest) {
 						const channel = client.default.channels.cache.get(this.id)
-						return channel.send(content)
+						return channel.send({ content, ...rest })
 					}
 				}
 			}

--- a/src/classes.js
+++ b/src/classes.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-async-promise-executor */
+import { partitionByMembership } from './dsf/scouts/membership.js'
 import { EmbedBuilder } from 'discord.js'
 import Color from './colors.js'
 import { nEmbed, paginate, paginateFollowUP } from './functions.js'
@@ -199,7 +200,19 @@ class ScouterCheck {
 	}
 
 	async _checkForScouts() {
-		const scouts = await this.potentialScouts
+		const candidates = await this.potentialScouts
+
+		// Only list people who are still here. A profile outlives its member, so
+		// without this the same departed users are proposed for the role every
+		// single week. checkRolesAdded/checkRolesRemoved already fetch members
+		// and skip them; this brings the embed in line.
+		const guild = await this.guild
+		const { present } = await partitionByMembership(
+			guild,
+			candidates.map((doc) => doc.userID)
+		)
+		const scouts = candidates.filter((doc) => present.has(doc.userID))
+
 		const fields = []
 
 		for (const values of scouts) {

--- a/src/dsf/scouts/membership.js
+++ b/src/dsf/scouts/membership.js
@@ -141,3 +141,15 @@ export const planReportDelivery = (chunks) => {
 
 	return { mode: 'file', content: chunks.join('\n'), chunkCount: chunks.length }
 }
+
+/**
+ * Split a report by who needs to see it.
+ *
+ * Someone holding a scouter role going inactive is a staffing matter, so it
+ * goes to the owners channel — as the old sweep did through logRemovedScouts.
+ * Everyone else is routine and belongs in the log channel.
+ */
+export const splitReportAudience = (entries) => ({
+	owners: entries.filter((entry) => entry.isScouter),
+	general: entries.filter((entry) => !entry.isScouter)
+})

--- a/src/dsf/scouts/membership.js
+++ b/src/dsf/scouts/membership.js
@@ -1,4 +1,5 @@
 import { logger } from '../../logging.js'
+import { splitMessage } from '../../functions.js'
 
 /**
  * Guild membership checks for scouter profiles.
@@ -70,4 +71,73 @@ export const markDepartedInactive = async (scoutTracker, departedIds) => {
 
 	if (result.modifiedCount) logger.info(`Marked ${result.modifiedCount} scouter profile(s) inactive: no longer in guild`)
 	return result.modifiedCount
+}
+
+/**
+ * How long a profile may be quiet before it is marked inactive.
+ *
+ * These are the thresholds the bot used before #196 removed the sweep: a plain
+ * profile with almost no activity goes quiet quickly, while someone who holds a
+ * scouter role is given a quarter before being counted out.
+ */
+const IDLE_DAYS = 31
+const SCOUTER_IDLE_DAYS = 90
+const LOW_ACTIVITY_TOTAL = 10
+
+const DAY_MS = 1000 * 60 * 60 * 24
+
+const totalActivity = (profile) =>
+	(profile.count ?? 0) +
+	(profile.otherCount ?? 0) +
+	(profile.alt1?.merchantCount ?? 0) +
+	(profile.alt1?.otherCount ?? 0) +
+	(profile.alt1First?.merchantCount ?? 0) +
+	(profile.alt1First?.otherCount ?? 0)
+
+/**
+ * Profiles that have gone quiet long enough to be marked inactive.
+ *
+ * Nothing is ever deleted. The old sweep removed profiles outright once they
+ * had been inactive for six months, which threw away the record of what someone
+ * did; marking them is enough, and the counts are still there if they return.
+ */
+export const selectInactiveProfiles = (profiles, now = Date.now()) =>
+	profiles.filter((profile) => {
+		if (profile.active !== 1) return false
+
+		const idleMs = now - (profile.lastTimestamp ?? 0)
+		const isScouter = (profile.assigned ?? []).length > 0
+
+		if (isScouter) return idleMs >= SCOUTER_IDLE_DAYS * DAY_MS
+
+		return idleMs >= IDLE_DAYS * DAY_MS && totalActivity(profile) < LOW_ACTIVITY_TOTAL
+	})
+
+/**
+ * The report for the log channel, split to fit Discord's 2000 character limit.
+ *
+ * A backlog of profiles marked in one run is easily longer than a single
+ * message, which is why this returns chunks rather than one string.
+ */
+export const buildInactiveReport = (entries) => {
+	if (!entries.length) return []
+
+	const lines = entries.map((entry) => `${entry.author} - ${entry.userID}: ${entry.reason}`)
+	return splitMessage(lines.join('\n'), { maxLength: 1900 })
+}
+
+/**
+ * How many messages are worth posting before switching to an attachment.
+ *
+ * The first run after a long gap has a backlog: 2362 profiles is 55 chunks,
+ * and posting those one by one would flood the log channel and risk a rate
+ * limit. Past this many, the whole report goes as a single file instead.
+ */
+const MAX_REPORT_MESSAGES = 5
+
+export const planReportDelivery = (chunks) => {
+	if (!chunks.length) return { mode: 'none' }
+	if (chunks.length <= MAX_REPORT_MESSAGES) return { mode: 'messages', chunks }
+
+	return { mode: 'file', content: chunks.join('\n'), chunkCount: chunks.length }
 }

--- a/src/dsf/scouts/membership.js
+++ b/src/dsf/scouts/membership.js
@@ -1,0 +1,73 @@
+import { logger } from '../../logging.js'
+
+/**
+ * Guild membership checks for scouter profiles.
+ *
+ * ScoutTracker keeps a profile forever, but people leave. Two things went wrong
+ * because nothing reconciled the two:
+ *
+ *  - the weekly "potential scouters" embed listed anyone whose counts qualified,
+ *    including people who had left, so the same departed users appeared every
+ *    week. checkRolesAdded/checkRolesRemoved already fetch members and so skip
+ *    them; only the embed path was blind to it.
+ *  - `active` was written once at profile creation and never updated, so no
+ *    profile had ever been marked inactive.
+ *
+ * Fetching by explicit user ids does not need the privileged GuildMembers
+ * intent (that is only required to request the *whole* member list), so this
+ * works with the bot's current intents.
+ */
+
+/** Discord accepts at most 100 user ids per member request. */
+const MAX_IDS_PER_FETCH = 100
+
+export const chunkIds = (ids, size = MAX_IDS_PER_FETCH) => {
+	const batches = []
+	for (let i = 0; i < ids.length; i += size) batches.push(ids.slice(i, i + size))
+	return batches
+}
+
+/**
+ * Split ids into those still in the guild and those who have left.
+ *
+ * A batch that fails is treated as unknown rather than departed: marking
+ * profiles inactive because Discord rate limited us would lose data that is
+ * expensive to reconstruct.
+ */
+export const partitionByMembership = async (guild, ids) => {
+	const present = new Set()
+	if (!ids.length) return { present, departed: [] }
+
+	const unknown = new Set()
+
+	for (const batch of chunkIds(ids)) {
+		try {
+			const members = await guild.members.fetch({ user: batch })
+			for (const id of members.keys()) present.add(id)
+		} catch (error) {
+			logger.error(`Could not check guild membership for ${batch.length} users: ${error.message}`)
+			for (const id of batch) unknown.add(id)
+		}
+	}
+
+	const departed = ids.filter((id) => !present.has(id) && !unknown.has(id))
+	return { present, departed }
+}
+
+/**
+ * Mark departed users' profiles inactive, keeping their stats.
+ *
+ * Profiles are never deleted: the counts are a record of what someone did, and
+ * they matter if the person comes back.
+ */
+export const markDepartedInactive = async (scoutTracker, departedIds) => {
+	if (!departedIds.length) return 0
+
+	const result = await scoutTracker.updateMany(
+		{ userID: { $in: departedIds }, active: 1 },
+		{ $set: { active: 0, leftAt: new Date() } }
+	)
+
+	if (result.modifiedCount) logger.info(`Marked ${result.modifiedCount} scouter profile(s) inactive: no longer in guild`)
+	return result.modifiedCount
+}

--- a/src/events/client/ready.js
+++ b/src/events/client/ready.js
@@ -1,6 +1,13 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-octal */
-import { markDepartedInactive, partitionByMembership } from '../../dsf/scouts/membership.js'
+import { codeBlock } from 'discord.js'
+import {
+	buildInactiveReport,
+	markDepartedInactive,
+	partitionByMembership,
+	planReportDelivery,
+	selectInactiveProfiles
+} from '../../dsf/scouts/membership.js'
 import { getEventChannel } from '../../dsf/calls/settingsAccess.js'
 import { updateAllMemberDataBaseRankRoles } from '../../alt1.js'
 import {
@@ -137,19 +144,61 @@ export default async (client) => {
 		})
 		await updateAllMemberDataBaseRankRoles(client, scout)
 
-		// Reconcile profiles against who is actually in the guild. `active` was
-		// only ever written when a profile was created, so nothing had marked a
-		// profile inactive since the bot was written. Profiles are kept, not
-		// deleted: the counts still matter if someone comes back.
+		// Reconcile profiles against who is actually in the guild, and against who
+		// has gone quiet. `active` was only ever set to 1, so nothing had marked a
+		// profile inactive since #196 removed the old sweep. Nothing is deleted:
+		// that sweep dropped profiles outright after six months, throwing away the
+		// record of what someone did.
 		try {
-			const activeProfiles = await scoutTracker.find({ active: 1 }, { projection: { userID: 1 } }).toArray()
+			const channels = await client.database.channels
+			const activeProfiles = await scoutTracker.find({ active: 1 }).toArray()
+			const byId = new Map(activeProfiles.map((profile) => [profile.userID, profile]))
+
 			const { departed } = await partitionByMembership(
 				await scout.guild,
-				activeProfiles.map((p) => p.userID)
+				activeProfiles.map((profile) => profile.userID)
 			)
 			await markDepartedInactive(scoutTracker, departed)
+
+			const stillPresent = activeProfiles.filter((profile) => !departed.includes(profile.userID))
+			const quiet = selectInactiveProfiles(stillPresent)
+			if (quiet.length) {
+				await scoutTracker.updateMany(
+					{ userID: { $in: quiet.map((profile) => profile.userID) }, active: 1 },
+					{ $set: { active: 0, inactiveSince: new Date() } }
+				)
+			}
+
+			// Chunked: a backlog marked in one run is longer than Discord allows
+			// in a single message.
+			const report = buildInactiveReport([
+				...departed.map((userID) => ({
+					author: byId.get(userID)?.author ?? 'unknown',
+					userID,
+					reason: 'left the server'
+				})),
+				...quiet.map((profile) => ({
+					author: profile.author,
+					userID: profile.userID,
+					reason: `no activity since ${new Date(profile.lastTimestamp).toISOString().slice(0, 10)}`
+				}))
+			])
+
+			const total = departed.length + quiet.length
+			const delivery = planReportDelivery(report)
+
+			if (delivery.mode === 'messages') {
+				for (const chunk of delivery.chunks) {
+					await channels.logs.send(`${total} profile(s) marked inactive.\n${codeBlock(chunk)}`)
+				}
+			} else if (delivery.mode === 'file') {
+				// A backlog is far too long for chat: one message, full list attached.
+				await channels.logs.send(`${total} profile(s) marked inactive. Full list attached.`, {
+					files: [{ attachment: Buffer.from(delivery.content, 'utf8'), name: 'inactive-profiles.txt' }]
+				})
+			}
 		} catch (error) {
-			client.logger.error(`Could not reconcile scouter profiles against guild membership: ${error.message}`)
+			client.logger.error(`Could not reconcile scouter profiles: ${error.message}`)
 		}
 
 		// Daily Reset

--- a/src/events/client/ready.js
+++ b/src/events/client/ready.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-vars */
 /* eslint-disable no-octal */
+import { markDepartedInactive, partitionByMembership } from '../../dsf/scouts/membership.js'
 import { getEventChannel } from '../../dsf/calls/settingsAccess.js'
 import { updateAllMemberDataBaseRankRoles } from '../../alt1.js'
 import {
@@ -135,6 +136,21 @@ export default async (client) => {
 			await removedRoles(role, scoutTracker)
 		})
 		await updateAllMemberDataBaseRankRoles(client, scout)
+
+		// Reconcile profiles against who is actually in the guild. `active` was
+		// only ever written when a profile was created, so nothing had marked a
+		// profile inactive since the bot was written. Profiles are kept, not
+		// deleted: the counts still matter if someone comes back.
+		try {
+			const activeProfiles = await scoutTracker.find({ active: 1 }, { projection: { userID: 1 } }).toArray()
+			const { departed } = await partitionByMembership(
+				await scout.guild,
+				activeProfiles.map((p) => p.userID)
+			)
+			await markDepartedInactive(scoutTracker, departed)
+		} catch (error) {
+			client.logger.error(`Could not reconcile scouter profiles against guild membership: ${error.message}`)
+		}
 
 		// Daily Reset
 		if (new Date().getHours() === 0o0 && new Date().getMinutes() === 0o0) {

--- a/src/events/client/ready.js
+++ b/src/events/client/ready.js
@@ -6,7 +6,8 @@ import {
 	markDepartedInactive,
 	partitionByMembership,
 	planReportDelivery,
-	selectInactiveProfiles
+	selectInactiveProfiles,
+	splitReportAudience
 } from '../../dsf/scouts/membership.js'
 import { getEventChannel } from '../../dsf/calls/settingsAccess.js'
 import { updateAllMemberDataBaseRankRoles } from '../../alt1.js'
@@ -169,33 +170,42 @@ export default async (client) => {
 				)
 			}
 
-			// Chunked: a backlog marked in one run is longer than Discord allows
-			// in a single message.
-			const report = buildInactiveReport([
+			const entries = [
 				...departed.map((userID) => ({
 					author: byId.get(userID)?.author ?? 'unknown',
 					userID,
-					reason: 'left the server'
+					reason: 'left the server',
+					isScouter: (byId.get(userID)?.assigned ?? []).length > 0
 				})),
 				...quiet.map((profile) => ({
 					author: profile.author,
 					userID: profile.userID,
-					reason: `no activity since ${new Date(profile.lastTimestamp).toISOString().slice(0, 10)}`
+					reason: `no activity since ${new Date(profile.lastTimestamp).toISOString().slice(0, 10)}`,
+					isScouter: (profile.assigned ?? []).length > 0
 				}))
-			])
+			]
 
-			const total = departed.length + quiet.length
-			const delivery = planReportDelivery(report)
+			// Scouters going inactive is a staffing matter, so they go to the
+			// owners channel; everyone else is routine and goes to the log
+			// channel. Both are chunked to Discord's message limit, and a large
+			// backlog goes as one attachment rather than dozens of messages.
+			const { owners, general } = splitReportAudience(entries)
 
-			if (delivery.mode === 'messages') {
-				for (const chunk of delivery.chunks) {
-					await channels.logs.send(`${total} profile(s) marked inactive.\n${codeBlock(chunk)}`)
+			for (const [channel, group, label] of [
+				[channels.dsfOwners, owners, 'scouter'],
+				[channels.logs, general, 'profile']
+			]) {
+				const delivery = planReportDelivery(buildInactiveReport(group))
+
+				if (delivery.mode === 'messages') {
+					for (const chunk of delivery.chunks) {
+						await channel.send(`${group.length} ${label}(s) marked inactive.\n${codeBlock(chunk)}`)
+					}
+				} else if (delivery.mode === 'file') {
+					await channel.send(`${group.length} ${label}(s) marked inactive. Full list attached.`, {
+						files: [{ attachment: Buffer.from(delivery.content, 'utf8'), name: `inactive-${label}s.txt` }]
+					})
 				}
-			} else if (delivery.mode === 'file') {
-				// A backlog is far too long for chat: one message, full list attached.
-				await channels.logs.send(`${total} profile(s) marked inactive. Full list attached.`, {
-					files: [{ attachment: Buffer.from(delivery.content, 'utf8'), name: 'inactive-profiles.txt' }]
-				})
 			}
 		} catch (error) {
 			client.logger.error(`Could not reconcile scouter profiles: ${error.message}`)

--- a/tests/membership.test.js
+++ b/tests/membership.test.js
@@ -7,7 +7,8 @@ import {
 	markDepartedInactive,
 	selectInactiveProfiles,
 	buildInactiveReport,
-	planReportDelivery
+	planReportDelivery,
+	splitReportAudience
 } from '../src/dsf/scouts/membership.js'
 
 const guildWith = (presentIds) => ({
@@ -273,4 +274,30 @@ test('the file plan keeps every line', () => {
 
 test('nothing to report means nothing to send', () => {
 	assert.equal(planReportDelivery([]).mode, 'none')
+})
+
+test('scouters are reported separately from everyone else', () => {
+	const { owners, general } = splitReportAudience([
+		{ author: 'a', userID: '1', reason: 'left the server', isScouter: true },
+		{ author: 'b', userID: '2', reason: 'left the server', isScouter: false }
+	])
+
+	assert.equal(owners.length, 1)
+	assert.equal(owners[0].userID, '1')
+	assert.equal(general.length, 1)
+	assert.equal(general[0].userID, '2')
+})
+
+test('no scouters means nothing for the owners channel', () => {
+	const { owners, general } = splitReportAudience([{ author: 'b', userID: '2', reason: 'quiet', isScouter: false }])
+
+	assert.deepEqual(owners, [])
+	assert.equal(general.length, 1)
+})
+
+test('entries without the flag are treated as general', () => {
+	const { owners, general } = splitReportAudience([{ author: 'b', userID: '2', reason: 'quiet' }])
+
+	assert.deepEqual(owners, [])
+	assert.equal(general.length, 1)
 })

--- a/tests/membership.test.js
+++ b/tests/membership.test.js
@@ -1,7 +1,14 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { chunkIds, partitionByMembership, markDepartedInactive } from '../src/dsf/scouts/membership.js'
+import {
+	chunkIds,
+	partitionByMembership,
+	markDepartedInactive,
+	selectInactiveProfiles,
+	buildInactiveReport,
+	planReportDelivery
+} from '../src/dsf/scouts/membership.js'
 
 const guildWith = (presentIds) => ({
 	members: {
@@ -153,4 +160,117 @@ test('markDepartedInactive does nothing when nobody departed', async () => {
 
 	assert.equal(called, false)
 	assert.equal(modified, 0)
+})
+
+// --- inactivity sweep -------------------------------------------------------
+
+const DAY = 1000 * 60 * 60 * 24
+const NOW = 1_800_000_000_000
+
+const profile = (over = {}) => ({
+	userID: '1',
+	author: 'someone',
+	count: 0,
+	otherCount: 0,
+	assigned: [],
+	active: 1,
+	lastTimestamp: NOW,
+	...over
+})
+
+test('a quiet low-count profile is marked inactive after 31 days', () => {
+	const selected = selectInactiveProfiles([profile({ otherCount: 5, lastTimestamp: NOW - 32 * DAY })], NOW)
+
+	assert.equal(selected.length, 1)
+})
+
+test('a quiet low-count profile is left alone before 31 days', () => {
+	const selected = selectInactiveProfiles([profile({ otherCount: 5, lastTimestamp: NOW - 20 * DAY })], NOW)
+
+	assert.deepEqual(selected, [])
+})
+
+test('a busy profile is not caught by the 31 day rule', () => {
+	const selected = selectInactiveProfiles([profile({ otherCount: 50, lastTimestamp: NOW - 40 * DAY })], NOW)
+
+	assert.deepEqual(selected, [])
+})
+
+test('a scouter is marked inactive after three months', () => {
+	const selected = selectInactiveProfiles(
+		[profile({ otherCount: 500, assigned: ['role1'], lastTimestamp: NOW - 100 * DAY })],
+		NOW
+	)
+
+	assert.equal(selected.length, 1)
+})
+
+test('a scouter quiet for only two months is left alone', () => {
+	const selected = selectInactiveProfiles(
+		[profile({ otherCount: 500, assigned: ['role1'], lastTimestamp: NOW - 60 * DAY })],
+		NOW
+	)
+
+	assert.deepEqual(selected, [])
+})
+
+test('profiles already inactive are not selected again', () => {
+	const selected = selectInactiveProfiles([profile({ active: 0, otherCount: 1, lastTimestamp: NOW - 400 * DAY })], NOW)
+
+	assert.deepEqual(selected, [])
+})
+
+test('the counted total includes alt1 counts', () => {
+	const busyViaAlt1 = profile({ alt1: { otherCount: 20 }, lastTimestamp: NOW - 40 * DAY })
+
+	assert.deepEqual(selectInactiveProfiles([busyViaAlt1], NOW), [])
+})
+
+test('the report says why each profile was marked', () => {
+	const lines = buildInactiveReport([{ author: 'a', userID: '1', reason: 'left the server' }])
+
+	assert.match(lines[0], /left the server/)
+	assert.match(lines[0], /a/)
+})
+
+test('the report splits into chunks under the Discord message limit', () => {
+	const many = Array.from({ length: 400 }, (_, i) => ({
+		author: `scouter-with-a-long-name-${i}`,
+		userID: String(100000000000000000 + i),
+		reason: 'no activity for 31 days'
+	}))
+
+	const chunks = buildInactiveReport(many)
+
+	assert.ok(chunks.length > 1)
+	for (const chunk of chunks) assert.ok(chunk.length <= 2000, `chunk was ${chunk.length}`)
+})
+
+test('the report is empty when nothing changed', () => {
+	assert.deepEqual(buildInactiveReport([]), [])
+})
+
+test('a small report is sent as chunked messages', () => {
+	const plan = planReportDelivery(['line one', 'line two'])
+
+	assert.equal(plan.mode, 'messages')
+	assert.equal(plan.chunks.length, 2)
+})
+
+test('a large report is sent as a single file instead of many messages', () => {
+	const plan = planReportDelivery(Array.from({ length: 55 }, (_, i) => `chunk ${i}`))
+
+	assert.equal(plan.mode, 'file')
+	assert.ok(plan.content.includes('chunk 54'))
+})
+
+test('the file plan keeps every line', () => {
+	const chunks = Array.from({ length: 20 }, (_, i) => `chunk ${i}`)
+	const plan = planReportDelivery(chunks)
+
+	for (const chunk of chunks) assert.ok(plan.content.includes(chunk))
+})
+
+test('nothing to report means nothing to send', () => {
+	assert.equal(planReportDelivery([]).mode, 'none')
 })

--- a/tests/membership.test.js
+++ b/tests/membership.test.js
@@ -1,0 +1,156 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { chunkIds, partitionByMembership, markDepartedInactive } from '../src/dsf/scouts/membership.js'
+
+const guildWith = (presentIds) => ({
+	members: {
+		fetch: async ({ user }) => {
+			const found = user.filter((id) => presentIds.includes(id))
+			return new Map(found.map((id) => [id, { id }]))
+		}
+	}
+})
+
+test('chunkIds splits into batches of the requested size', () => {
+	assert.deepEqual(chunkIds(['1', '2', '3', '4', '5'], 2), [['1', '2'], ['3', '4'], ['5']])
+})
+
+test('chunkIds returns nothing for an empty list', () => {
+	assert.deepEqual(chunkIds([], 100), [])
+})
+
+test('chunkIds keeps a short list in one batch', () => {
+	assert.deepEqual(chunkIds(['1', '2'], 100), [['1', '2']])
+})
+
+test('partitionByMembership separates present from departed', async () => {
+	const { present, departed } = await partitionByMembership(guildWith(['1', '3']), ['1', '2', '3'])
+
+	assert.deepEqual([...present].sort(), ['1', '3'])
+	assert.deepEqual(departed, ['2'])
+})
+
+test('everyone departed when the guild has none of them', async () => {
+	const { present, departed } = await partitionByMembership(guildWith([]), ['1', '2'])
+
+	assert.equal(present.size, 0)
+	assert.deepEqual(departed, ['1', '2'])
+})
+
+test('nobody departed when all are present', async () => {
+	const { departed } = await partitionByMembership(guildWith(['1', '2']), ['1', '2'])
+
+	assert.deepEqual(departed, [])
+})
+
+test('handles an empty id list without calling Discord', async () => {
+	let called = false
+	const guild = {
+		members: {
+			fetch: async () => {
+				called = true
+				return new Map()
+			}
+		}
+	}
+
+	const { present, departed } = await partitionByMembership(guild, [])
+
+	assert.equal(called, false)
+	assert.equal(present.size, 0)
+	assert.deepEqual(departed, [])
+})
+
+test('batches large id lists so Discord is not asked for more than 100 at once', async () => {
+	const seen = []
+	const guild = {
+		members: {
+			fetch: async ({ user }) => {
+				seen.push(user.length)
+				return new Map()
+			}
+		}
+	}
+
+	await partitionByMembership(
+		guild,
+		Array.from({ length: 250 }, (_, i) => String(i))
+	)
+
+	assert.deepEqual(seen, [100, 100, 50])
+})
+
+test('a failed batch is treated as unknown rather than departed', async () => {
+	const guild = {
+		members: {
+			fetch: async () => {
+				throw new Error('rate limited')
+			}
+		}
+	}
+
+	const { departed } = await partitionByMembership(guild, ['1', '2'])
+
+	// Nobody is marked departed on an error: that would wrongly deactivate profiles.
+	assert.deepEqual(departed, [])
+})
+
+test('markDepartedInactive sets active to 0 for departed users only', async () => {
+	const calls = []
+	const collection = {
+		updateMany: async (filter, update) => {
+			calls.push({ filter, update })
+			return { modifiedCount: filter.userID.$in.length }
+		}
+	}
+
+	const modified = await markDepartedInactive(collection, ['1', '2'])
+
+	assert.deepEqual(calls[0].filter.userID.$in, ['1', '2'])
+	assert.equal(calls[0].update.$set.active, 0)
+	assert.equal(modified, 2)
+})
+
+test('markDepartedInactive records when they were found to have left', async () => {
+	const calls = []
+	const collection = {
+		updateMany: async (filter, update) => {
+			calls.push(update)
+			return { modifiedCount: 1 }
+		}
+	}
+
+	await markDepartedInactive(collection, ['1'])
+
+	assert.ok(calls[0].$set.leftAt instanceof Date)
+})
+
+test('markDepartedInactive only touches profiles still marked active', async () => {
+	const calls = []
+	const collection = {
+		updateMany: async (filter) => {
+			calls.push(filter)
+			return { modifiedCount: 0 }
+		}
+	}
+
+	await markDepartedInactive(collection, ['1'])
+
+	assert.equal(calls[0].active, 1)
+})
+
+test('markDepartedInactive does nothing when nobody departed', async () => {
+	let called = false
+	const collection = {
+		updateMany: async () => {
+			called = true
+			return { modifiedCount: 0 }
+		}
+	}
+
+	const modified = await markDepartedInactive(collection, [])
+
+	assert.equal(called, false)
+	assert.equal(modified, 0)
+})


### PR DESCRIPTION
## Root cause

Both reported problems have one cause: **nothing reconciles ScoutTracker profiles against who is actually in the guild**, and the sweep that used to do it was removed.

### 1. The weekly embed keeps proposing people who left

`ScouterCheck.potentialScouts` (`classes.js:142`) filters profiles on counts, elapsed time and `assigned` — never membership. `_checkForScouts()` builds the embed straight from that.

The five candidates it is proposing right now, checked against the Discord API:

```
446633167663661066: NOT IN SERVER (404)
240515306970284032: NOT IN SERVER (404)
351134770773753859: NOT IN SERVER (404)
264485320471347210: NOT IN SERVER (404)
1112722067108941835: NOT IN SERVER (404)
```

Every one. Nobody currently in the server qualifies, so the embed is *entirely* departed users — hence the same names weekly. `checkRolesAdded()`/`checkRolesRemoved()` already fetch members and skip them; only the embed path was blind.

### 2. Nothing has ever been marked inactive

`active` is set to `1` on profile creation and re-set to `1` whenever someone posts a call (`counts.js:113,129`) — but **never set to `0` anywhere**. #196 removed `removeInactives`, which was the only thing that did it. So:

```
total profiles: 3466
  active === 1: 3465
```

The deletion mechanism went with it — `removeInactives` used to `deleteOne` any profile inactive for six months. That deletion is **not** coming back.

## Fix

New `src/dsf/scouts/membership.js`:

- **Embed** filters candidates by guild membership before rendering
- **Departed members** are marked `active: 0` with a `leftAt` date
- **Quiet profiles** are marked `active: 0` with an `inactiveSince` date, using the pre-#196 thresholds: under 10 calls → 31 days; holding a scouter role → 90 days
- **Nothing is deleted.** The counts record what someone did and matter if they return

### Reporting

Scouters go to the **owners channel**, everyone else to the **log channel** — the split `logRemovedScouts` made before it was removed. Both are chunked to Discord's 2000-character limit.

Past five chunks the report goes as a **single attachment** instead. That matters on the first run: simulated against live data, it marks **2362 profiles**, which is **55 chunks**. Posting those individually would flood the channel and risk a rate limit.

## Design notes

- **No privileged intent needed.** Fetching by explicit user ids is exempt; only requesting the whole member list requires `GuildMembers`.
- **Batched at 100 ids**, Discord's per-request cap.
- **A failed batch counts as unknown, not departed** — a rate limit must never deactivate real members.
- The whole sweep is wrapped in try/catch so it cannot break the rest of the cron.

## Tests

30 new (167 total): batching, membership partitioning, failure-is-not-departure, the update shape, both inactivity thresholds, alt1 counts included in the activity total, report chunking under the limit, the file fallback, and the owners/log audience split.

## After merging

The first run marks ~2362 profiles inactive and posts one attachment per channel. Worth confirming the number looks like a real backlog rather than a fetch failure — **82 of them hold a scouter role**, so the owners channel gets its own list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)