### PR TITLE
fix(calls): build the call regexes from the world registry

### DIFF
--- a/src/dsf/calls/callCount.js
+++ b/src/dsf/calls/callCount.js
@@ -1,5 +1,4 @@
 import { ActionRowBuilder, ButtonBuilder, ButtonStyle } from 'discord.js'
-import { FOREIGN_WORLD_REGEX } from './constants.js'
 
 const foreignWorldFlags = {
 	'🇩🇪': [102, 121, 260],
@@ -7,7 +6,9 @@ const foreignWorldFlags = {
 	'🇧🇷': [47, 75, 101, 279]
 }
 
-export const buttonFunctions = (userN, content) => {
+// foreignWorldRegex is passed in because it is derived from the world
+// registry, which is read where the call is handled.
+export const buttonFunctions = (userN, content, foreignWorldRegex = null) => {
 	const buttonSelection = new ActionRowBuilder().addComponents([
 		new ButtonBuilder()
 			.setCustomId(`DM ${userN.user.username}`)
@@ -41,8 +42,8 @@ export const buttonFunctions = (userN, content) => {
 	])
 
 	let foreignWorldNumber = 0
-	if (FOREIGN_WORLD_REGEX.test(content)) {
-		foreignWorldNumber = parseInt(/\d{2,3}/.exec(FOREIGN_WORLD_REGEX.exec(content)[0]))
+	if (foreignWorldRegex && foreignWorldRegex.test(content)) {
+		foreignWorldNumber = parseInt(/\d{2,3}/.exec(foreignWorldRegex.exec(content)[0]))
 	}
 
 	const buttonSelectionForeignWorlds = new ActionRowBuilder().addComponents([

--- a/src/dsf/calls/callRegex.js
+++ b/src/dsf/calls/callRegex.js
@@ -1,0 +1,102 @@
+/**
+ * Call-matching regexes, built from the world registry.
+ *
+ * These used to be literals in constants.js with the world numbers spelled out
+ * as an alternation:
+ *
+ *     (([124569]|1[0234568]|…|21[12-479]|22[67-9]|238|25[2-47-9]|26[1-9]|…)
+ *
+ * That list was last season's league worlds. When the worlds changed, calls on
+ * the new ones — `sm 172`, `sm 143` — stopped matching and were routed to the
+ * spam channel instead of being counted. Nobody edits a regex when a season
+ * starts, so it drifts every time.
+ *
+ * Building them from the registry means a season needs `/worlds set leagues …`
+ * and nothing else.
+ */
+
+import { deriveMemberWorlds } from './worldRegistry.js'
+
+/** The call prefixes: every event abbreviation and full name. */
+const EVENT_PREFIXES = [
+	'wp',
+	'j',
+	'jf',
+	'wh',
+	'sm',
+	'tt',
+	'a',
+	'ark',
+	'whirlpool',
+	'whale',
+	'jelly',
+	'jellyfish',
+	'pool',
+	'sea monster',
+	'treasure turtle',
+	'turtle',
+	'arkaneo',
+	'sailfish'
+]
+
+/** The foreign form also allows a bare world prefix, e.g. "world 299". */
+const FOREIGN_PREFIXES = ['w', 'world', ...EVENT_PREFIXES]
+
+// What may follow the world number: a separator, "ua"/"f" markers, or free text.
+const TRAILING = '(([,.\\s]|ua|f)?|\\s[\\W\\w\\+]*)*'
+
+const prefixGroup = (prefixes) => `(?:${prefixes.join('|')}){1}`
+
+// Longest first so 172 wins over 17 when both are members.
+const worldGroup = (worlds) =>
+	`(?:${[...worlds]
+		.map(Number)
+		.sort((a, b) => b - a)
+		.join('|')})`
+
+/** Matches a call on one of the given member worlds. */
+export const buildCallRegex = (memberWorlds) =>
+	new RegExp(`(^${prefixGroup(EVENT_PREFIXES)}\\s?(${worldGroup(memberWorlds)}${TRAILING})$)`, 'i')
+
+/**
+ * Matches a call on a world that is *not* a member world.
+ *
+ * Used to offer the "foreign world" buttons rather than counting the call.
+ * Any 1-3 digit world that the registry does not know about qualifies, so this
+ * no longer needs its own hardcoded list either.
+ */
+export const buildForeignWorldRegex = (memberWorlds) => {
+	const members = new Set([...memberWorlds].map(Number))
+	const foreign = []
+	for (let world = 1; world <= 999; world++) if (!members.has(world)) foreign.push(world)
+
+	return new RegExp(`(^${prefixGroup(FOREIGN_PREFIXES)}\\s?(${worldGroup(foreign)}${TRAILING})$)`, 'i')
+}
+
+/**
+ * Cached per registry version.
+ *
+ * Both regexes are rebuilt only when the registry changes: the foreign one
+ * enumerates every non-member world up to 999, which is not work to repeat on
+ * every message in a busy call channel.
+ */
+const cache = { version: null, call: null, foreign: null }
+
+const refresh = (registry) => {
+	if (cache.version === registry.version && cache.call) return
+
+	const memberWorlds = deriveMemberWorlds(registry)
+	cache.version = registry.version
+	cache.call = buildCallRegex(memberWorlds)
+	cache.foreign = buildForeignWorldRegex(memberWorlds)
+}
+
+export const callRegexFor = (registry) => {
+	refresh(registry)
+	return cache.call
+}
+
+export const foreignWorldRegexFor = (registry) => {
+	refresh(registry)
+	return cache.foreign
+}

--- a/src/dsf/calls/constants.js
+++ b/src/dsf/calls/constants.js
@@ -1,8 +1,4 @@
 /* eslint-disable no-useless-escape */
-export const OTHER_CALLS_REGEX =
-	/(^(?:wp|j|jf|wh|sm|tt|a|ark|whirlpool|whale|jelly|jellyfish|pool|sea monster|treasure turtle|turtle|arkaneo|sailfish){1}\s?(([124569]|1[0234568]|2[1-8]|3[0125-79]|4[024-689]|5[0-689]|6[02-9]|7[0-46-9]|8[2-9]|9[126-9]|10[03-6]|11[4-79]|12[34]|13[47-9]|140|21[12-479]|22[67-9]|238|25[2-47-9]|26[1-9]|27[0-8]|28[0-9]|29[0-8])(([,.\s]|ua|f)?|\s[\W\w\+]*)*)$)/i
-export const FOREIGN_WORLD_REGEX =
-	/(^(?:w|world|wp|j|jf|wh|sm|tt|a|ark|whirlpool|whale|jelly|jellyfish|pool|sea monster|treasure turtle|turtle|arkaneo|sailfish){1}\s?((47|75|10[12]|118|121|142|218|237|260|279|299)(([,.\s]|ua|f)?|\s[\W\w\+]*)*)$)/i
 export const TEN_MINUTES = 600_000
 export const ALL_EVENTS_REGEX =
 	/^((?<whirlpool>wp|whirlpool|pool)|(?<sea_monster>sm|sea monster)|(?<jellyfish>j|jf|jelly|jellyfish)|(?<whale>wh|whale)|(?<treasure_turtle>tt|turtle|treasure turtle)|(?<arkaneo>a|ark|arkaneo|sailfish))\s?\d{1,3}.*$/i

--- a/src/dsf/calls/counts.js
+++ b/src/dsf/calls/counts.js
@@ -1,4 +1,5 @@
-import { OTHER_CALLS_REGEX, FOREIGN_WORLD_REGEX } from './constants.js'
+import { callRegexFor, foreignWorldRegexFor } from './callRegex.js'
+import { getRegistry } from './worlds.js'
 import { checkMemberRole, messageInArray, worldAlreadyCalled } from './merchFunctions.js'
 import { buttonFunctions } from './callCount.js'
 
@@ -22,7 +23,10 @@ export const addCount = async (client, message, alt1Count = false) => {
 			)) ?? {}
 
 		const callChannel = client.channels.cache.get(otherChannelID)
-		const callRegex = OTHER_CALLS_REGEX
+		// Built from the registry, so a new league season needs no code change.
+		const registry = await getRegistry(db)
+		const callRegex = callRegexFor(registry)
+		const foreignWorldRegex = foreignWorldRegexFor(registry)
 		const callDataBaseMessages = otherMessages
 
 		const dsfServerErrorChannel = await client.channels.cache.get('794608385106509824') // bot-logs-admin
@@ -33,7 +37,7 @@ export const addCount = async (client, message, alt1Count = false) => {
 		const timestamp = message.createdAt.toString().split(' ').slice(0, 5).join(' ')
 
 		const [buttonSelection, buttonSelectionExtra, buttonSelectionForeignWorlds, buttonSelectionAlreadyCalled] =
-			buttonFunctions(callerMember, message.content)
+			buttonFunctions(callerMember, message.content, foreignWorldRegex)
 
 		const callCheckPass = (message, includedWords, dataBaseMessages, regexCheck) => {
 			return (
@@ -51,7 +55,7 @@ export const addCount = async (client, message, alt1Count = false) => {
 			}posted before)\n\n- User ID: <@!${callerMember.id}>\n- User: ${callerMember.user.username}\n- Content: ${
 				message.content
 			}\n- Timestamp: ${timestamp}\n- Channel: ${callChannel.name}\`\`\``,
-			components: FOREIGN_WORLD_REGEX.test(message.content)
+			components: foreignWorldRegex.test(message.content)
 				? [buttonSelectionForeignWorlds]
 				: worldAlreadyCalled(message, callDataBaseMessages) || alt1Count
 					? [buttonSelectionAlreadyCalled]

--- a/tests/callRegex.test.js
+++ b/tests/callRegex.test.js
@@ -1,0 +1,84 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { buildCallRegex, buildForeignWorldRegex, callRegexFor, foreignWorldRegexFor } from '../src/dsf/calls/callRegex.js'
+
+const MEMBERS = [1, 2, 84, 143, 172, 173, 260]
+
+test('a call on a member world passes', () => {
+	assert.ok(buildCallRegex(MEMBERS).test('sm 172'))
+})
+
+test('a call on a league world added this season passes', () => {
+	assert.ok(buildCallRegex(MEMBERS).test('sm 143'))
+})
+
+test('the event abbreviations still work', () => {
+	const regex = buildCallRegex(MEMBERS)
+
+	for (const call of ['wp 84', 'jf 84', 'wh 84', 'tt 84', 'ark 84', 'sea monster 84', 'whirlpool 84']) {
+		assert.ok(regex.test(call), `${call} should pass`)
+	}
+})
+
+test('a world that is not a member world does not pass', () => {
+	assert.ok(!buildCallRegex(MEMBERS).test('sm 999'))
+})
+
+test('a world that only shares a prefix does not pass', () => {
+	// 17 must not match because 172 is a member; the regex is anchored per world.
+	assert.ok(!buildCallRegex(MEMBERS).test('sm 17'))
+})
+
+test('trailing notes after the world are allowed', () => {
+	assert.ok(buildCallRegex(MEMBERS).test('sm 172 crashed'))
+	assert.ok(buildCallRegex(MEMBERS).test('sm 172, 5 mins'))
+})
+
+test('a message that is not a call does not pass', () => {
+	assert.ok(!buildCallRegex(MEMBERS).test('hello everyone'))
+})
+
+test('a bare world number is not a call', () => {
+	assert.ok(!buildCallRegex(MEMBERS).test('172'))
+})
+
+test('the foreign regex matches a world that is not a member world', () => {
+	assert.ok(buildForeignWorldRegex(MEMBERS).test('sm 299'))
+})
+
+test('the foreign regex does not match a member world', () => {
+	assert.ok(!buildForeignWorldRegex(MEMBERS).test('sm 172'))
+})
+
+test('the foreign regex accepts the world prefix form', () => {
+	assert.ok(buildForeignWorldRegex(MEMBERS).test('world 299'))
+})
+
+test('regexes are rebuilt when the member worlds change', () => {
+	const before = buildCallRegex([84])
+	const after = buildCallRegex([84, 172])
+
+	assert.ok(!before.test('sm 172'))
+	assert.ok(after.test('sm 172'))
+})
+
+test('the cached regexes rebuild when the registry version changes', () => {
+	const v1 = { version: 1, baseWorlds: [84], specials: [] }
+	const v2 = { version: 2, baseWorlds: [84], specials: [{ key: 'leagues', label: 'L', enabled: true, worlds: [172] }] }
+
+	assert.ok(!callRegexFor(v1).test('sm 172'))
+	assert.ok(callRegexFor(v2).test('sm 172'))
+})
+
+test('the same registry version reuses the cached regex', () => {
+	const registry = { version: 5, baseWorlds: [84], specials: [] }
+
+	assert.equal(callRegexFor(registry), callRegexFor(registry))
+})
+
+test('the foreign regex is cached the same way', () => {
+	const registry = { version: 7, baseWorlds: [84], specials: [] }
+
+	assert.equal(foreignWorldRegexFor(registry), foreignWorldRegexFor(registry))
+})


### PR DESCRIPTION
## The bug

Calls on this season's league worlds are being treated as spam. Reported from the logs:

```
+ Spam Message 1538343573236351057 - (User has not posted before)
- Content: sm 172
- Channel: dsf-calls
```

`sm 172` is a perfectly valid call. The reason it failed is `OTHER_CALLS_REGEX` in `constants.js`, which spelled the world numbers out as a literal alternation:

```
(…|21[12-479]|22[67-9]|238|25[2-47-9]|26[1-9]|27[0-8]|28[0-9]|29[0-8])
```

Those are **last season's** league worlds. This season's — 143, 146-147, 172-175, 190, 208-209, 220-221, 240-241, 248, 260 — aren't in it:

```
sm 172   FAIL          sm 84   PASS
sm 143   FAIL          sm 190  FAIL
```

So `callCheckPassed` was false and the message went to the spam channel instead of being counted. This affected **every user**, not just new ones — "User has not posted before" is just extra context in that log line.

## Root cause

This was the **fourth hardcoded copy** of the world list. The registry replaced the other three (server, Alt1 client, reaction emoji), but this one was missed — it's a regex, so it didn't look like a world list.

Both regexes are now built from the registry and cached per version. A new league season needs `/worlds set leagues …` and nothing else; no code change, no missed calls.

The foreign-world regex is derived the same way — anything the registry doesn't know about — rather than its own hardcoded list (`47|75|10[12]|118|121|142|218|237|260|279|299`), which had gone stale identically: 142, 218 and 237 are last season's league worlds, and 260 is one of *this* season's, so it was being treated as foreign while also being a member world.

## Verified against the live registry (v4)

```
"sm 172"          call:PASS  foreign:no
"sm 143"          call:PASS  foreign:no
"wp 84"           call:PASS  foreign:no
"sm 999"          call:fail  foreign:yes
"sm 17"           call:fail  foreign:yes     ← prefix of 172, correctly not matched
"hello"           call:fail  foreign:no
"sm 172 crashed"  call:PASS  foreign:no
```

## Tests

15 new (182 total): every event abbreviation, member vs non-member worlds, prefix collisions (17 vs 172), trailing notes after the world, non-calls, bare numbers, the foreign-world form, and cache invalidation when the registry version changes.

## Note

Worth merging promptly — league-world calls are being dropped in production right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)