### PR TITLE
feat(misty): add /misty to open the Alt1 Misty tab to everyone

### DIFF
--- a/src/commands/misty.js
+++ b/src/commands/misty.js
@@ -1,0 +1,107 @@
+import { SlashCommandBuilder } from '@discordjs/builders'
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder, MessageFlags } from 'discord.js'
+
+import Color from '../colors.js'
+import { buildWindow, describeWindow, CLIENT_FEATURES_DOCUMENT_ID } from '../dsf/calls/mistyWindow.js'
+
+const CONFIRM_TIMEOUT_MS = 60_000
+
+export default {
+	name: 'misty',
+	// One description per usage entry: help.js pairs them by index.
+	description: [
+		'Opens the Alt1 Misty tab to everyone signed in, optionally for a set period.',
+		'Closes the Misty tab again, leaving it visible to Scouters only.',
+		'Shows whether the Misty tab is currently open, and until when.'
+	],
+	usage: ['open <duration> <reason>', 'close', 'status'],
+	guildSpecific: ['668330890790699079', '420803245758480405'],
+	permissionLevel: 'Admin',
+	data: new SlashCommandBuilder()
+		.setName('misty')
+		.setDescription('Control who can see the Alt1 Misty tab.')
+		.addSubcommand((sub) =>
+			sub
+				.setName('open')
+				.setDescription('Open the Misty tab to everyone signed in.')
+				.addStringOption((option) =>
+					option.setName('duration').setDescription('How long to stay open, e.g. 90m, 48h, 3d').setRequired(false)
+				)
+				.addStringOption((option) =>
+					option.setName('reason').setDescription('Shown in the app, e.g. Double XP weekend').setRequired(false)
+				)
+		)
+		.addSubcommand((sub) => sub.setName('close').setDescription('Close the Misty tab again (Scouters only).'))
+		.addSubcommand((sub) => sub.setName('status').setDescription('Show whether the Misty tab is currently open.')),
+	slash: async (client, interaction, perms) => {
+		if (!perms.admin) return interaction.reply(perms.errorA)
+
+		const settings = client.database.settings
+		const subcommand = interaction.options.getSubcommand()
+
+		const stored = await settings.findOne({ _id: CLIENT_FEATURES_DOCUMENT_ID })
+		const current = stored?.mistyPublic ?? { open: false }
+
+		if (subcommand === 'status') {
+			return interaction.reply({
+				embeds: [new EmbedBuilder().setTitle('Misty tab').setColor(Color.cream).setDescription(describeWindow(current))]
+			})
+		}
+
+		let next
+		try {
+			next = buildWindow({
+				close: subcommand === 'close',
+				duration: interaction.options.getString('duration'),
+				reason: interaction.options.getString('reason'),
+				userId: interaction.user.id
+			})
+		} catch (error) {
+			return interaction.reply({ content: `❌ ${error.message}`, flags: MessageFlags.Ephemeral })
+		}
+
+		const embed = new EmbedBuilder()
+			.setTitle(subcommand === 'close' ? 'Close the Misty tab?' : 'Open the Misty tab?')
+			.setColor(Color.cream)
+			.setDescription(`**Now:** ${describeWindow(current)}\n\n**After:** ${describeWindow(next)}`)
+			.setFooter({ text: 'Everyone signed in can see world states while it is open. Editing stays Scouter-only.' })
+
+		const confirmId = `misty-confirm-${interaction.id}`
+		const buttons = new ActionRowBuilder().addComponents(
+			new ButtonBuilder().setCustomId(confirmId).setLabel('Confirm').setStyle(ButtonStyle.Success),
+			new ButtonBuilder().setCustomId(`misty-cancel-${interaction.id}`).setLabel('Cancel').setStyle(ButtonStyle.Secondary)
+		)
+
+		const message = await interaction.reply({ embeds: [embed], components: [buttons], withResponse: true })
+		const sent = message.resource?.message ?? (await interaction.fetchReply())
+
+		let click
+		try {
+			click = await sent.awaitMessageComponent({
+				filter: (component) => component.user.id === interaction.user.id,
+				time: CONFIRM_TIMEOUT_MS
+			})
+		} catch {
+			return interaction.editReply({
+				embeds: [embed.setFooter({ text: 'Timed out — nothing changed.' })],
+				components: []
+			})
+		}
+
+		if (click.customId !== confirmId) {
+			return click.update({ embeds: [embed.setFooter({ text: 'Cancelled — nothing changed.' })], components: [] })
+		}
+
+		// Written whole so the server's change stream sees the complete state.
+		await settings.updateOne(
+			{ _id: CLIENT_FEATURES_DOCUMENT_ID },
+			{ $set: { mistyPublic: next, updatedAt: new Date(), updatedBy: interaction.user.id } },
+			{ upsert: true }
+		)
+
+		await click.update({
+			embeds: [embed.setFooter({ text: `Applied by ${interaction.user.tag}` })],
+			components: []
+		})
+	}
+}

--- a/src/dsf/calls/mistyWindow.js
+++ b/src/dsf/calls/mistyWindow.js
@@ -1,0 +1,66 @@
+/**
+ * The Misty tab public window.
+ *
+ * The Alt1 Misty tab is normally Scouter-only. This is the switch that opens it
+ * to any signed-in user for a while — a double XP weekend, an event, a quiet
+ * spell where more eyes on world states helps.
+ *
+ * Stored as a ClientFeatures document in the Settings collection, which
+ * DSF-Server watches with its change stream and pushes to connected clients.
+ * The server treats an `until` in the past as closed, so a timed window shuts
+ * itself and nobody has to remember the closing command.
+ */
+
+export const CLIENT_FEATURES_DOCUMENT_ID = 'ClientFeatures'
+
+const UNITS = { m: 60 * 1000, h: 60 * 60 * 1000, d: 24 * 60 * 60 * 1000 }
+
+/** Windows longer than this are almost certainly a typo, not an intention. */
+const MAX_DURATION_MS = 31 * UNITS.d
+
+/** "48h", "3d", "90m" -> milliseconds. */
+export const parseDuration = (input) => {
+	const match = /^(\d+)\s*([mhd])$/i.exec((input ?? '').trim())
+	if (!match) throw new Error(`\`${input}\` is not a duration. Use e.g. 90m, 48h or 3d.`)
+
+	const amount = Number(match[1])
+	const ms = amount * UNITS[match[2].toLowerCase()]
+	if (ms <= 0) throw new Error('That duration is not long enough to be useful.')
+	if (ms > MAX_DURATION_MS) throw new Error('That is longer than a month; open it for a shorter period.')
+
+	return ms
+}
+
+/**
+ * Build the window to store.
+ *
+ * Without a duration the window stays open until someone closes it, which is
+ * deliberate: some occasions do not have a known end.
+ */
+export const buildWindow = ({ duration = null, reason = null, userId, close = false, now = new Date() } = {}) => {
+	if (close) return { open: false, until: null, reason: null, setBy: userId }
+
+	return {
+		open: true,
+		until: duration ? new Date(now.getTime() + parseDuration(duration)) : null,
+		reason: reason ?? null,
+		setBy: userId
+	}
+}
+
+const isActive = (window) => {
+	if (!window?.open) return false
+	if (!window.until) return true
+	return new Date(window.until).getTime() > Date.now()
+}
+
+/** A sentence describing the window, for the confirmation and for /misty status. */
+export const describeWindow = (window) => {
+	if (!isActive(window)) return 'The Misty tab is **closed** — Scouters only.'
+
+	const reason = window.reason ? ` Reason: ${window.reason}.` : ''
+	if (!window.until) return `The Misty tab is **open** to everyone signed in, until it is closed by hand.${reason}`
+
+	const unix = Math.floor(new Date(window.until).getTime() / 1000)
+	return `The Misty tab is **open** to everyone signed in until <t:${unix}:f> (<t:${unix}:R>).${reason}`
+}

--- a/tests/mistyWindow.test.js
+++ b/tests/mistyWindow.test.js
@@ -1,0 +1,81 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { parseDuration, buildWindow, describeWindow, CLIENT_FEATURES_DOCUMENT_ID } from '../src/dsf/calls/mistyWindow.js'
+
+const NOW = new Date('2026-08-16T00:00:00Z')
+
+test('parseDuration understands hours', () => {
+	assert.equal(parseDuration('48h'), 48 * 60 * 60 * 1000)
+})
+
+test('parseDuration understands days', () => {
+	assert.equal(parseDuration('3d'), 3 * 24 * 60 * 60 * 1000)
+})
+
+test('parseDuration understands minutes', () => {
+	assert.equal(parseDuration('90m'), 90 * 60 * 1000)
+})
+
+test('parseDuration rejects nonsense', () => {
+	assert.throws(() => parseDuration('soon'), /duration/i)
+})
+
+test('parseDuration rejects zero and negatives', () => {
+	assert.throws(() => parseDuration('0h'), /duration/i)
+	assert.throws(() => parseDuration('-2h'), /duration/i)
+})
+
+test('parseDuration rejects a window longer than a month', () => {
+	assert.throws(() => parseDuration('60d'), /longer than/i)
+})
+
+test('buildWindow sets an end from the duration', () => {
+	const window = buildWindow({ duration: '48h', reason: 'DXP', userId: '1', now: NOW })
+
+	assert.equal(window.open, true)
+	assert.equal(window.until.toISOString(), '2026-08-18T00:00:00.000Z')
+	assert.equal(window.reason, 'DXP')
+	assert.equal(window.setBy, '1')
+})
+
+test('buildWindow without a duration stays open until closed by hand', () => {
+	const window = buildWindow({ userId: '1', now: NOW })
+
+	assert.equal(window.open, true)
+	assert.equal(window.until, null)
+})
+
+test('closing produces a closed window', () => {
+	const window = buildWindow({ close: true, userId: '1', now: NOW })
+
+	assert.equal(window.open, false)
+})
+
+test('describeWindow reports a timed window with a Discord timestamp', () => {
+	const text = describeWindow(buildWindow({ duration: '48h', reason: 'DXP', userId: '1', now: NOW }))
+
+	assert.match(text, /open/i)
+	assert.match(text, /<t:\d+:[Rf]>/)
+	assert.match(text, /DXP/)
+})
+
+test('describeWindow reports an open-ended window', () => {
+	const text = describeWindow(buildWindow({ userId: '1', now: NOW }))
+
+	assert.match(text, /until it is closed/i)
+})
+
+test('describeWindow reports a closed window', () => {
+	assert.match(describeWindow(buildWindow({ close: true, userId: '1', now: NOW })), /closed/i)
+})
+
+test('describeWindow reports an expired window as closed', () => {
+	const expired = { open: true, until: new Date('2020-01-01T00:00:00Z'), reason: null }
+
+	assert.match(describeWindow(expired), /closed|expired/i)
+})
+
+test('the document id matches what the server watches', () => {
+	assert.equal(CLIENT_FEATURES_DOCUMENT_ID, 'ClientFeatures')
+})


### PR DESCRIPTION
## Why

The Misty tab is Scouter-only, but the app was built around the travelling merchant and that's gone. This makes the tab something you can open up — for a double XP weekend, an event, or a quiet spell where more eyes on world states helps.

```
/misty open 48h Double XP weekend
/misty open                          ← open until closed by hand
/misty close
/misty status
```

## How it works

Writes a `ClientFeatures` document to the `Settings` collection — the same collection and change-stream path the world registry uses. DSF-Server validates it, applies it, and pushes it to connected clients, so the tab unblurs live without anyone restarting the app.

A duration stores an end date, and the server treats a past date as closed. So a timed window **shuts itself** — nobody has to remember `/misty close` on Monday morning.

Admin-gated, with the confirm-preview pattern from `/worlds`:

```
Open the Misty tab?
Now:   The Misty tab is closed — Scouters only.
After: The Misty tab is open to everyone signed in until <t:…:f> (<t:…:R>). Reason: Double XP weekend.

Everyone signed in can see world states while it is open. Editing stays Scouter-only.
```

## Scope

**Viewing** opens up. **Editing** timers and mod actions stay exactly as they are — the window widens who can look, not who can change things. Guests who haven't linked Discord still don't get world state; the server requires an authenticated connection even during the window.

## Depends on

DSF-Server #101, which adds the `ClientFeatures` document handling and, more importantly, makes the gate real: before it, world state was broadcast to every socket regardless of role, so the client-side blur was decoration. Without that PR this command changes nothing observable.

## Tests

14 new (196 total): duration parsing including rejections (nonsense, zero, negative, over a month), window construction with and without an end, closing, and the description text for timed, open-ended, closed and expired windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)