### PR TITLE
fix(privacy): register the command against the guilds that read content

### DIFF
--- a/src/commands/privacy.js
+++ b/src/commands/privacy.js
@@ -37,7 +37,9 @@ export default {
 		'Shows your current choice and what the bot stores.'
 	],
 	usage: ['optout', 'optin', 'status'],
-	guildSpecific: 'all',
+	// The registration script filters on guildSpecific.includes(guildId), so the
+	// string 'all' would match nothing and the command would never publish.
+	guildSpecific: ['668330890790699079', '420803245758480405'],
 	permissionLevel: 'Everyone',
 	data: new SlashCommandBuilder()
 		.setName('privacy')


### PR DESCRIPTION
Caught while publishing `/privacy` to production: it would not have registered at all.

`src/slashCommands.js` selects commands with:

```js
command.guildSpecific.includes(guildId)
```

`/privacy` was written with `guildSpecific: 'all'`, following the convention `messageCreate` uses for prefix commands (`command.guildSpecific === 'all' || ...`). The registration script has no such branch, so `'all'.includes('420803245758480405')` is `false` and the command is filtered out — silently, with the script reporting success for everything else.

It is now listed against the DSF server and the dev guild, matching `/misty`.

Worth knowing: the script has **no path for a genuinely global command**. The global `PUT` is commented out because it replaces the guild's entire command list and deletes the manually registered context menus. So "available everywhere" is not currently something this repo can express — a follow-up if the opt-out should reach all ~105 guilds rather than the one where calls are actually read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)