### PR TITLE
feat(events): drop the countdown from a call once the event has ended

### DIFF
--- a/src/dsf/calls/eventTimers.js
+++ b/src/dsf/calls/eventTimers.js
@@ -34,6 +34,46 @@ export const buildWebhookEditRequest = (messageId, content) => ({
  */
 export const isValidDuration = (durationMs) => Number.isFinite(durationMs) && durationMs >= 0
 
+/** The webhook posts under this name; only its own messages can be edited. */
+const WEBHOOK_AUTHOR = 'Alt1 Tracker'
+
+/**
+ * The edit that removes the countdown from a call that has just expired, or
+ * null when there is nothing to do.
+ *
+ * The webhook posts "JF105 (Called by 5Ftx) | Ends <t:1786886538:R>". Discord
+ * renders `:R>` relatively, so once the event is over the message reads "3
+ * minutes ago" and keeps counting up for as long as it exists. Stripping the
+ * timer was already written, but only reachable through overrideEventTimer —
+ * a Misty update or a mod delete — so an event that simply ran out kept its
+ * stale countdown next to the skull.
+ */
+export const expiryEdit = (message) => {
+	if (message?.author?.username !== WEBHOOK_AUTHOR) return null
+
+	const content = updateMessageTimestamp(message.content, 0)
+	if (content === message.content) return null
+
+	return buildWebhookEditRequest(message.id, content)
+}
+
+/**
+ * Remove the countdown from an expired call.
+ *
+ * Never throws: the event has ended either way, and a failed tidy-up should not
+ * take out skulling or the reaction permissions cleanup.
+ */
+const stripExpiredTimer = async (message) => {
+	const edit = expiryEdit(message)
+	if (!edit) return
+
+	try {
+		await axios.patch(edit.url, edit.body, edit.config)
+	} catch (error) {
+		console.error('Failed to strip the expired timer:', error.response?.data?.detail || error.message)
+	}
+}
+
 export async function startEventTimer({ client, message, eventId, channelName, durationMs, database }) {
 	// Validate inputs
 	if (!eventId || !message || !client || !isValidDuration(durationMs)) {
@@ -50,6 +90,7 @@ export async function startEventTimer({ client, message, eventId, channelName, d
 			try {
 				await skullTimer(client, message, channelName)
 				await removeReactPermissions(message, database)
+				await stripExpiredTimer(message)
 			} catch (err) {
 				console.error(`[${eventId}] ❌ Error in timer completion:`, err)
 			} finally {
@@ -147,6 +188,7 @@ export async function overrideEventTimer(eventId, newDurationMs, mistyUpdate = f
 			try {
 				await skullTimer(current.client, current.message, current.channelName)
 				await removeReactPermissions(current.message, current.database)
+				await stripExpiredTimer(current.message)
 			} catch (err) {
 				console.error(`[${eventId}] ❌ Error in updated timer completion:`, err)
 			} finally {

--- a/tests/eventTimers.test.js
+++ b/tests/eventTimers.test.js
@@ -1,7 +1,7 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { buildWebhookEditRequest, isValidDuration } from '../src/dsf/calls/eventTimers.js'
+import { buildWebhookEditRequest, expiryEdit, isValidDuration } from '../src/dsf/calls/eventTimers.js'
 
 test('the webhook edit sends the API key as a header', () => {
 	// The key used to be passed inside the request body, where axios sends it
@@ -46,4 +46,38 @@ test('a duration that is not a number is rejected', () => {
 	assert.equal(isValidDuration(null), false)
 	assert.equal(isValidDuration(undefined), false)
 	assert.equal(isValidDuration(NaN), false)
+})
+
+// The webhook posts "JF105 (Called by 5Ftx) | Ends <t:1786886538:R>". Discord
+// renders :R> relatively, so once the event is over it reads "3 minutes ago"
+// and keeps counting up. Nothing edited it on natural expiry: the strip existed
+// but was only reachable through overrideEventTimer, which fires on a Misty
+// update or a mod delete, never on an event simply running out.
+const webhookMessage = (content, username = 'Alt1 Tracker') => ({ id: '99', content, author: { username } })
+
+const CALL = 'JF105 (Called by 5Ftx) | Ends <t:1786886538:R>'
+
+test('an expired webhook call has its timer stripped', () => {
+	const edit = expiryEdit(webhookMessage(CALL))
+
+	assert.equal(edit.body.content, 'JF105 (Called by 5Ftx)')
+})
+
+test('the edit targets the message that expired', () => {
+	const edit = expiryEdit(webhookMessage(CALL))
+
+	assert.match(edit.url, /\/events\/webhook\/99$/)
+})
+
+test('a call from a player is left alone', () => {
+	// Only the webhook's own messages can be edited through the API.
+	assert.equal(expiryEdit(webhookMessage(CALL, 'someone')), null)
+})
+
+test('a webhook message with no timer needs no edit', () => {
+	assert.equal(expiryEdit(webhookMessage('JF105 (Called by 5Ftx)')), null)
+})
+
+test('a message with no author is left alone', () => {
+	assert.equal(expiryEdit({ id: '99', content: CALL }), null)
 })


### PR DESCRIPTION
The webhook posts:

```
JF105 (Called by 5Ftx) | Ends <t:1786886538:R>
```

Discord renders `:R>` relatively, so it counts down and then keeps counting **up** — "3 minutes ago", forever — sitting next to the skull that says the event is over.

### Why nothing fixed it

The strip already existed. `updateMessageTimestamp(content, 0)` removes the ` | Ends …` clause, and that is what a mod delete or a Misty update triggers. But it was only reachable through `overrideEventTimer`. An event that simply **ran out** goes down a different path — `startEventTimer` → `skullTimer` → react and clean up — which never touched the message content.

Both expiry paths now call it, after skulling and clearing the reaction permissions.

### It could not have worked before

`buildWebhookEditRequest` was only fixed in #256. Until then the PATCH sent its API key inside the request body rather than as a header, so `require_bot_api_key` rejected every edit and the failure appeared only in the bot's own logs. So this feature depends on that fix having shipped.

### Failure behaviour

`stripExpiredTimer` never throws. The event has ended either way, and failing to tidy the message must not take out the skull or the permission cleanup that follow it in the same `try`.

### Tests

`expiryEdit` returns the request or null, so the decision is testable without a network:

- an expired webhook call has its timer stripped → `JF105 (Called by 5Ftx)`
- the edit targets the right message
- a call posted by a player is left alone — only the webhook's own messages can be edited through the API
- a webhook message with no timer needs no edit
- a message with no author is left alone

246 tests passing, up from 241. Format and eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)