### PR TITLE
fix(scouts): await the role writes, and stop restoring counts as NaN

### DIFF
--- a/src/dsf/scouts/scouters.js
+++ b/src/dsf/scouts/scouters.js
@@ -14,61 +14,75 @@ const classVars = async (name, serverName, database, client, scouters) => {
 	name._scouters = scouters
 }
 
+// Promise.all, not map: the callbacks were started and never awaited, so this
+// resolved while the writes were still in flight. Anything reading the profiles
+// back saw the old state, and a failure inside became an unhandled rejection
+// rather than something the caller could catch.
 const addedRoles = async (name, scoutTracker) => {
 	const members = await name.checkRolesAdded()
-	members.map(async (x) => {
-		const role = await name.role
-		await scoutTracker.updateOne(
-			{ userID: x.id },
-			{
-				$addToSet: {
-					assigned: role.id
+	await Promise.all(
+		members.map(async (x) => {
+			const role = await name.role
+			await scoutTracker.updateOne(
+				{ userID: x.id },
+				{
+					$addToSet: {
+						assigned: role.id
+					}
+				}
+			)
+			// Add a check to see if they have the oldScout. If they do, re-add count once verified scouter
+			if (name.roleName === 'Verified Scouter') {
+				const trackerProfile = await scoutTracker.findOne({ userID: x.id })
+				// No profile for someone who has never reported an event.
+				if (trackerProfile?.oldScout) {
+					const oldAlt1MerchantCount = trackerProfile.oldScout.alt1?.merchantCount ?? 0
+					const oldAlt1OtherCount = trackerProfile.oldScout.alt1?.otherCount ?? 0
+					const oldAlt1FirstMerchantCount = trackerProfile.oldScout.alt1First?.merchantCount ?? 0
+					const oldAlt1FirstOtherCount = trackerProfile.oldScout.alt1First?.otherCount ?? 0
+					await scoutTracker.updateOne(
+						{ userID: trackerProfile.userID },
+						{
+							$set: {
+								// Every addend is defaulted: oldScout documents predate some
+								// of these fields, `undefined + number` is NaN, and Mongo
+								// stores NaN happily — poisoning every later total and the
+								// thresholds that read them.
+								count: (trackerProfile.count ?? 0) + (trackerProfile.oldScout.count ?? 0),
+								otherCount: (trackerProfile.otherCount ?? 0) + (trackerProfile.oldScout.otherCount ?? 0),
+								'alt1.merchantCount': (trackerProfile.alt1?.merchantCount ?? 0) + oldAlt1MerchantCount,
+								'alt1.otherCount': (trackerProfile.alt1?.otherCount ?? 0) + oldAlt1OtherCount,
+								'alt1First.merchantCount':
+									(trackerProfile.alt1First?.merchantCount ?? 0) + oldAlt1FirstMerchantCount,
+								'alt1First.otherCount': (trackerProfile.alt1First?.otherCount ?? 0) + oldAlt1FirstOtherCount,
+								firstTimestamp: trackerProfile.oldScout.firstTimestamp ?? trackerProfile.firstTimestamp
+							},
+							$unset: {
+								oldScout: 1
+							}
+						}
+					)
 				}
 			}
-		)
-		// Add a check to see if they have the oldScout. If they do, re-add count once verified scouter
-		if (name.roleName === 'Verified Scouter') {
-			const trackerProfile = await scoutTracker.findOne({ userID: x.id })
-			if (trackerProfile.oldScout) {
-				const oldAlt1MerchantCount = trackerProfile.oldScout.alt1?.merchantCount ?? 0
-				const oldAlt1OtherCount = trackerProfile.oldScout.alt1?.otherCount ?? 0
-				const oldAlt1FirstMerchantCount = trackerProfile.oldScout.alt1First?.merchantCount ?? 0
-				const oldAlt1FirstOtherCount = trackerProfile.oldScout.alt1First?.otherCount ?? 0
-				await scoutTracker.updateOne(
-					{ userID: trackerProfile.userID },
-					{
-						$set: {
-							count: trackerProfile.count + trackerProfile.oldScout.count,
-							otherCount: trackerProfile.otherCount + trackerProfile.oldScout.otherCount,
-							'alt1.merchantCount': (trackerProfile.alt1?.merchantCount ?? 0) + oldAlt1MerchantCount,
-							'alt1.otherCount': (trackerProfile.alt1?.otherCount ?? 0) + oldAlt1OtherCount,
-							'alt1First.merchantCount': (trackerProfile.alt1First?.merchantCount ?? 0) + oldAlt1FirstMerchantCount,
-							'alt1First.otherCount': (trackerProfile.alt1First?.otherCount ?? 0) + oldAlt1FirstOtherCount,
-							firstTimestamp: trackerProfile.oldScout.firstTimestamp
-						},
-						$unset: {
-							oldScout: 1
-						}
-					}
-				)
-			}
-		}
-	})
+		})
+	)
 }
 
 const removedRoles = async (name, scoutTracker) => {
 	const checkRoles = await name.checkRolesRemoved()
-	checkRoles.map(async (x) => {
-		const role = await name.role
-		await scoutTracker.updateOne(
-			{ userID: x.id },
-			{
-				$pull: {
-					assigned: role.id
+	await Promise.all(
+		checkRoles.map(async (x) => {
+			const role = await name.role
+			await scoutTracker.updateOne(
+				{ userID: x.id },
+				{
+					$pull: {
+						assigned: role.id
+					}
 				}
-			}
-		)
-	})
+			)
+		})
+	)
 }
 
 export { scout, vScout, classVars, addedRoles, removedRoles }

--- a/tests/scouterRoles.test.js
+++ b/tests/scouterRoles.test.js
@@ -1,0 +1,112 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+
+import { addedRoles, removedRoles } from '../src/dsf/scouts/scouters.js'
+
+const checker = (roleName, members, roleId = 'role-1') => ({
+	roleName,
+	role: Promise.resolve({ id: roleId }),
+	checkRolesAdded: async () => members,
+	checkRolesRemoved: async () => members
+})
+
+const tracker = (profiles = {}) => {
+	const writes = []
+	return {
+		writes,
+		findOne: async ({ userID }) => profiles[userID] ?? null,
+		updateOne: async (filter, update) => {
+			writes.push({ filter, update })
+			return { modifiedCount: 1 }
+		}
+	}
+}
+
+test('a newly assigned role is recorded against the profile', async () => {
+	const db = tracker()
+
+	await addedRoles(checker('Scouter', [{ id: '1' }]), db)
+
+	assert.equal(db.writes.length, 1)
+	assert.deepEqual(db.writes[0].update.$addToSet, { assigned: 'role-1' })
+})
+
+test('every member is written before the call resolves', async () => {
+	// `members.map(async ...)` starts the writes without awaiting them, so the
+	// function resolved while they were still in flight. Anything sequencing
+	// work after it — or reading the profiles back — saw the old state.
+	const db = tracker()
+
+	await addedRoles(checker('Scouter', [{ id: '1' }, { id: '2' }, { id: '3' }]), db)
+
+	assert.equal(db.writes.length, 3)
+})
+
+test('a removed role is pulled from the profile', async () => {
+	const db = tracker()
+
+	await removedRoles(checker('Scouter', [{ id: '1' }]), db)
+
+	assert.deepEqual(db.writes[0].update.$pull, { assigned: 'role-1' })
+})
+
+test('every removal is written before the call resolves', async () => {
+	const db = tracker()
+
+	await removedRoles(checker('Scouter', [{ id: '1' }, { id: '2' }]), db)
+
+	assert.equal(db.writes.length, 2)
+})
+
+test('becoming a Verified Scouter restores the counts held in oldScout', async () => {
+	const db = tracker({
+		1: {
+			userID: '1',
+			count: 5,
+			otherCount: 2,
+			oldScout: { count: 10, otherCount: 3, firstTimestamp: 100 }
+		}
+	})
+
+	await addedRoles(checker('Verified Scouter', [{ id: '1' }]), db)
+
+	const restore = db.writes.find((write) => write.update.$set)
+	assert.equal(restore.update.$set.count, 15)
+	assert.equal(restore.update.$set.otherCount, 5)
+	assert.equal(restore.update.$set.firstTimestamp, 100)
+	assert.deepEqual(restore.update.$unset, { oldScout: 1 })
+})
+
+test('a profile with no oldScout is left alone', async () => {
+	const db = tracker({ 1: { userID: '1', count: 5, otherCount: 2 } })
+
+	await addedRoles(checker('Verified Scouter', [{ id: '1' }]), db)
+
+	assert.equal(
+		db.writes.every((write) => !write.update.$set),
+		true
+	)
+})
+
+test('a missing profile does not throw', async () => {
+	// findOne returns null for someone with no profile, and reading .oldScout
+	// off that is a TypeError inside an unawaited async callback — an unhandled
+	// rejection rather than something the caller can catch.
+	const db = tracker({})
+
+	await assert.doesNotReject(() => addedRoles(checker('Verified Scouter', [{ id: 'nobody' }]), db))
+})
+
+test('missing counts never write NaN', async () => {
+	// oldScout documents predate some of these fields. `undefined + number` is
+	// NaN, and Mongo stores it, which poisons every later total and the
+	// thresholds that read them.
+	const db = tracker({ 1: { userID: '1', oldScout: { firstTimestamp: 100 } } })
+
+	await addedRoles(checker('Verified Scouter', [{ id: '1' }]), db)
+
+	const restore = db.writes.find((write) => write.update.$set)
+	for (const [field, value] of Object.entries(restore?.update.$set ?? {})) {
+		assert.equal(Number.isNaN(value), false, `${field} was written as NaN`)
+	}
+})


### PR DESCRIPTION
Testing `scouters.js` — role assignment and count restoration — turned up two bugs, one hiding the other.

## Fire and forget

```js
members.map(async (x) => { ... await scoutTracker.updateOne(...) })
```

`map` starts the callbacks and returns an array of promises nobody awaits, so `addedRoles` and `removedRoles` resolved **while their writes were still in flight**. Anything reading the profiles back saw the old state, and a failure inside became an unhandled rejection rather than something the caller could catch.

Both are wrapped in `Promise.all` now.

## Which was hiding NaN

Folding a Verified Scouter's `oldScout` counts back in read every addend without a default:

```js
count: trackerProfile.count + trackerProfile.oldScout.count
```

`oldScout` documents predate some of those fields. `undefined + number` is **NaN**, and Mongo stores NaN happily — poisoning the profile's totals and every threshold that reads them, permanently and invisibly.

The test for this **passed vacuously** before the first fix: the write had not happened yet when the assertion ran, so there was nothing to inspect. Only once the writes were awaited did it fail and expose the second defect. Every addend is defaulted now.

Also: `findOne` returns `null` for someone who has never reported an event, and reading `.oldScout` off that threw inside the unawaited callback — an unhandled rejection, not a catchable error.

## Production

No profile currently holds an `oldScout`, so nothing needs repairing. The NaN path only runs when someone is promoted to Verified Scouter while carrying restored history.

## Tests

8 new, covering: role added and pulled, every member written before the call resolves, counts restored and `oldScout` unset, a profile without `oldScout` left alone, a missing profile, and no field ever written as NaN.

**328 tests passing**, up from 320.

🤖 Generated with [Claude Code](https://claude.com/claude-code)