### PR TITLE
feat(scouts): strip scouter roles when a profile goes inactive

### DIFF
--- a/src/classes.js
+++ b/src/classes.js
@@ -176,7 +176,13 @@ class ScouterCheck {
 		})
 	}
 
+	// An inactive profile has had its roles stripped, so `assigned` is empty
+	// again while the counts stay well past the threshold. Without this, the
+	// weekly embed proposes every ex-scouter the inactivity sweep just removed.
+	// Only an explicit 0 counts: documents predating the flag have no `active`.
 	_checkScouts(filter, num, time) {
+		if (filter.active === 0) return undefined
+
 		const totalCount =
 			(filter.count ?? 0) +
 			(filter.otherCount ?? 0) +
@@ -191,6 +197,8 @@ class ScouterCheck {
 	}
 
 	_checkVerifiedScouts(filter, num, time) {
+		if (filter.active === 0) return undefined
+
 		const totalCount =
 			(filter.count ?? 0) +
 			(filter.otherCount ?? 0) +

--- a/src/dsf/scouts/membership.js
+++ b/src/dsf/scouts/membership.js
@@ -44,10 +44,10 @@ export const chunkIds = (ids, size = MAX_IDS_PER_FETCH) => {
  * so a batch that fails is split and retried instead. A single id that still
  * fails is genuinely unknown.
  */
-const fetchBatch = async (guild, batch, present) => {
+const fetchBatch = async (guild, batch, members) => {
 	try {
-		const members = await guild.members.fetch({ user: batch })
-		for (const id of members.keys()) present.add(id)
+		const fetched = await guild.members.fetch({ user: batch })
+		for (const [id, member] of fetched) members.set(id, member)
 		return []
 	} catch (error) {
 		if (batch.length === 1) {
@@ -59,24 +59,30 @@ const fetchBatch = async (guild, batch, present) => {
 		const half = Math.ceil(batch.length / 2)
 		const failed = []
 		for (const smaller of chunkIds(batch, half)) {
-			failed.push(...(await fetchBatch(guild, smaller, present)))
+			failed.push(...(await fetchBatch(guild, smaller, members)))
 		}
 		return failed
 	}
 }
 
+/**
+ * The fetched members come back alongside the partition: removing a role needs
+ * the member object, and re-fetching one per candidate would repeat work this
+ * has already done.
+ */
 export const partitionByMembership = async (guild, ids) => {
-	const present = new Set()
-	if (!ids.length) return { present, departed: [] }
+	const members = new Map()
+	if (!ids.length) return { present: new Set(), departed: [], members }
 
 	const unknown = new Set()
 
 	for (const batch of chunkIds(ids)) {
-		for (const id of await fetchBatch(guild, batch, present)) unknown.add(id)
+		for (const id of await fetchBatch(guild, batch, members)) unknown.add(id)
 	}
 
+	const present = new Set(members.keys())
 	const departed = ids.filter((id) => !present.has(id) && !unknown.has(id))
-	return { present, departed }
+	return { present, departed, members }
 }
 
 /**
@@ -164,6 +170,114 @@ export const planReportDelivery = (chunks) => {
 	if (chunks.length <= MAX_REPORT_MESSAGES) return { mode: 'messages', chunks }
 
 	return { mode: 'file', content: chunks.join('\n'), chunkCount: chunks.length }
+}
+
+/**
+ * Profiles whose Discord roles no longer match their inactive status.
+ *
+ * Marking a profile inactive never touched the roles, so someone could sit at
+ * `active: 0` while still holding Scouter. This covers the profiles this run
+ * marked and the backlog left by earlier runs in one rule.
+ *
+ * Only an explicit 0 qualifies. selectInactiveProfiles can afford to read a
+ * missing `active` field as not-active because the cost is skipping a profile;
+ * here the cost is taking the roles off a working scouter whose document
+ * predates the flag.
+ */
+export const selectStrippable = (profiles) =>
+	profiles.filter((profile) => profile.active === 0 && (profile.assigned ?? []).length > 0)
+
+/**
+ * Roles the bot can actually take off someone.
+ *
+ * Discord checks the position of the *role being changed*, not the target's own
+ * highest role, so the only questions are whether the role sits below the bot
+ * and whether an integration owns it. Filtering once per run turns what would
+ * be a 403 per member into a single warning.
+ */
+export const strippableRoles = (roles) =>
+	roles.filter((role) => {
+		if (role.managed) {
+			logger.warn(`Cannot remove ${role.name}: the role is managed by an integration.`)
+			return false
+		}
+
+		if (!role.editable) {
+			logger.warn(`Cannot remove ${role.name}: the role sits above the bot's highest role.`)
+			return false
+		}
+
+		return true
+	})
+
+const UNKNOWN_MEMBER = 10007
+const MISSING_PERMISSIONS = 50013
+
+const STRIP_REASON = 'Scouter profile marked inactive'
+
+/**
+ * Take the scouter roles off members whose profile is inactive.
+ *
+ * Only what Discord actually accepted is pulled from `assigned`, so a removal
+ * that fails leaves the database agreeing with the guild rather than claiming a
+ * role is gone when it is not.
+ *
+ * Nobody who is absent is written to. A departed member's roles left with them,
+ * and `assigned` is the record of what they held if they return; a member whose
+ * fetch failed is unknown rather than gone, the same way partitionByMembership
+ * treats them.
+ */
+export const stripInactiveRoles = async ({ guild, roles, profiles, scoutTracker }) => {
+	const candidates = selectStrippable(profiles)
+	if (!candidates.length) return []
+
+	const manageable = strippableRoles(roles)
+	if (!manageable.length) return []
+
+	const { members } = await partitionByMembership(
+		guild,
+		candidates.map((profile) => profile.userID)
+	)
+
+	const entries = []
+
+	for (const profile of candidates) {
+		const member = members.get(profile.userID)
+		if (!member) continue
+
+		const removed = []
+
+		for (const role of manageable) {
+			if (!member.roles.cache.has(role.id)) continue
+
+			try {
+				await member.roles.remove(role, STRIP_REASON)
+				removed.push(role)
+			} catch (error) {
+				if (error.code === UNKNOWN_MEMBER) {
+					logger.warn(`${profile.userID} left before their roles could be removed.`)
+					break
+				}
+
+				const detail = error.code === MISSING_PERMISSIONS ? 'missing permissions' : error.message
+				logger.error(`Could not remove ${role.name} from ${profile.userID}: ${detail}`)
+			}
+		}
+
+		if (!removed.length) continue
+
+		await scoutTracker.updateOne({ userID: profile.userID }, { $pullAll: { assigned: removed.map((role) => role.id) } })
+
+		entries.push({
+			author: profile.author,
+			userID: profile.userID,
+			reason: `role(s) removed: ${removed.map((role) => role.name).join(', ')}`,
+			isScouter: true
+		})
+	}
+
+	if (entries.length) logger.info(`Removed scouter roles from ${entries.length} inactive profile(s)`)
+	return entries
 }
 
 /**

--- a/src/dsf/scouts/scouters.js
+++ b/src/dsf/scouts/scouters.js
@@ -85,4 +85,21 @@ const removedRoles = async (name, scoutTracker) => {
 	)
 }
 
-export { scout, vScout, classVars, addedRoles, removedRoles }
+/**
+ * Reconcile every role's assignments in turn.
+ *
+ * The cron ran this as `[scout, vScout].forEach(async ...)`, which starts both
+ * and resolves straight away — so the rank update sequenced after it read the
+ * profiles while these writes were still in flight, and a failure inside became
+ * an unhandled rejection. Same bug as the one inside addedRoles, one level up.
+ *
+ * Sequential, not Promise.all: both roles write to the same profiles.
+ */
+const syncAssignedRoles = async (roles, scoutTracker) => {
+	for (const role of roles) {
+		await addedRoles(role, scoutTracker)
+		await removedRoles(role, scoutTracker)
+	}
+}
+
+export { scout, vScout, classVars, addedRoles, removedRoles, syncAssignedRoles }

--- a/src/events/client/clientReady.js
+++ b/src/events/client/clientReady.js
@@ -7,7 +7,8 @@ import {
 	partitionByMembership,
 	planReportDelivery,
 	selectInactiveProfiles,
-	splitReportAudience
+	splitReportAudience,
+	stripInactiveRoles
 } from '../../dsf/scouts/membership.js'
 import { getEventChannel } from '../../dsf/calls/settingsAccess.js'
 import { updateAllMemberDataBaseRankRoles } from '../../alt1.js'
@@ -15,8 +16,7 @@ import {
 	scout,
 	vScout,
 	classVars,
-	addedRoles,
-	removedRoles,
+	syncAssignedRoles,
 	mistyEventTimer,
 	skullTimer,
 	removeReactPermissions
@@ -140,10 +140,7 @@ export default async (client) => {
 	cron.schedule('0 */6 * * *', async () => {
 		const scoutTracker = client.database.scoutTracker
 		await initScouterDataBase(client, db)
-		;[scout, vScout].forEach(async (role) => {
-			await addedRoles(role, scoutTracker)
-			await removedRoles(role, scoutTracker)
-		})
+		await syncAssignedRoles([scout, vScout], scoutTracker)
 		await updateAllMemberDataBaseRankRoles(client, scout)
 
 		// Reconcile profiles against who is actually in the guild, and against who
@@ -171,6 +168,18 @@ export default async (client) => {
 				)
 			}
 
+			// Marking a profile inactive left the Discord role in place, so an
+			// inactive scouter kept scouter permissions until someone noticed.
+			// This runs after the marking so it covers what this run marked and
+			// the backlog every run before it left behind. Anyone who has left
+			// the guild is skipped: their roles went with them.
+			const stripped = await stripInactiveRoles({
+				guild: await scout.guild,
+				roles: [await scout.role, await vScout.role].filter(Boolean),
+				profiles: await scoutTracker.find({ active: 0, 'assigned.0': { $exists: true } }).toArray(),
+				scoutTracker
+			})
+
 			const entries = [
 				...departed.map((userID) => ({
 					author: byId.get(userID)?.author ?? 'unknown',
@@ -183,7 +192,8 @@ export default async (client) => {
 					userID: profile.userID,
 					reason: `no activity since ${new Date(profile.lastTimestamp).toISOString().slice(0, 10)}`,
 					isScouter: (profile.assigned ?? []).length > 0
-				}))
+				})),
+				...stripped
 			]
 
 			// Scouters going inactive is a staffing matter, so they go to the

--- a/tests/membership.test.js
+++ b/tests/membership.test.js
@@ -8,7 +8,10 @@ import {
 	selectInactiveProfiles,
 	buildInactiveReport,
 	planReportDelivery,
-	splitReportAudience
+	splitReportAudience,
+	selectStrippable,
+	strippableRoles,
+	stripInactiveRoles
 } from '../src/dsf/scouts/membership.js'
 
 const guildWith = (presentIds) => ({
@@ -343,4 +346,260 @@ test('a batch that fails however small it gets is left unknown', async () => {
 
 	assert.equal(present.size, 0)
 	assert.deepEqual(departed, [])
+})
+
+// Stripping a role needs the member object, not just the id. Returning what was
+// already fetched keeps it to one round of requests rather than a second fetch
+// per candidate.
+test('partitionByMembership hands back the members it fetched', async () => {
+	const { members } = await partitionByMembership(guildWith(['1', '3']), ['1', '2', '3'])
+
+	assert.deepEqual([...members.keys()].sort(), ['1', '3'])
+	assert.equal(members.get('1').id, '1')
+})
+
+test('selectStrippable picks inactive profiles that still hold a role', () => {
+	const selected = selectStrippable([
+		{ userID: '1', active: 0, assigned: ['r1'] },
+		{ userID: '2', active: 1, assigned: ['r1'] },
+		{ userID: '3', active: 0, assigned: [] }
+	])
+
+	assert.deepEqual(
+		selected.map((profile) => profile.userID),
+		['1']
+	)
+})
+
+// /privacy optout upserts profiles with no assigned list at all.
+test('selectStrippable tolerates a profile with no assigned list', () => {
+	assert.deepEqual(selectStrippable([{ userID: '1', active: 0 }]), [])
+})
+
+// Documents predating the flag have no `active` field. Reading that as inactive
+// would take the roles off scouters who are still working.
+test('selectStrippable leaves a profile predating the active flag alone', () => {
+	assert.deepEqual(selectStrippable([{ userID: '1', assigned: ['r1'] }]), [])
+})
+
+test('strippableRoles keeps roles the bot sits above', () => {
+	const scouter = { id: 'r1', name: 'Scouter', editable: true, managed: false }
+
+	assert.deepEqual(strippableRoles([scouter]), [scouter])
+})
+
+// Every removal would 403. Dropping the role once beats N failed requests.
+test('strippableRoles drops a role positioned above the bot', () => {
+	assert.deepEqual(strippableRoles([{ id: 'r1', name: 'Scouter', editable: false, managed: false }]), [])
+})
+
+test('strippableRoles drops a role Discord manages', () => {
+	assert.deepEqual(strippableRoles([{ id: 'r1', name: 'Booster', editable: true, managed: true }]), [])
+})
+
+const scouterRole = { id: 'r1', name: 'Scouter', editable: true, managed: false }
+const verifiedRole = { id: 'r2', name: 'Verified Scouter', editable: true, managed: false }
+
+const discordError = (code) => Object.assign(new Error(`Discord ${code}`), { code })
+
+const memberWith = (id, roleIds, { failWith = {} } = {}) => {
+	const held = new Set(roleIds)
+	const member = { id, removed: [], reasons: [] }
+	member.roles = {
+		cache: { has: (roleId) => held.has(roleId) },
+		remove: async (role, reason) => {
+			if (failWith[role.id]) throw failWith[role.id]
+			held.delete(role.id)
+			member.removed.push(role.id)
+			member.reasons.push(reason)
+			return member
+		}
+	}
+	return member
+}
+
+const guildOf = (members) => {
+	const guild = { fetches: 0 }
+	guild.members = {
+		fetch: async ({ user }) => {
+			guild.fetches += 1
+			return new Map(user.filter((id) => members[id]).map((id) => [id, members[id]]))
+		}
+	}
+	return guild
+}
+
+const tracker = () => {
+	const writes = []
+	return { writes, updateOne: async (filter, update) => writes.push({ filter, update }) }
+}
+
+test('stripInactiveRoles removes every strippable role the member still holds', async () => {
+	const member = memberWith('1', ['r1', 'r2'])
+	const scoutTracker = tracker()
+
+	await stripInactiveRoles({
+		guild: guildOf({ 1: member }),
+		roles: [scouterRole, verifiedRole],
+		profiles: [{ userID: '1', author: 'a', active: 0, assigned: ['r1', 'r2'] }],
+		scoutTracker
+	})
+
+	assert.deepEqual(member.removed, ['r1', 'r2'])
+})
+
+test('the removal carries a reason for the audit log', async () => {
+	const member = memberWith('1', ['r1'])
+
+	await stripInactiveRoles({
+		guild: guildOf({ 1: member }),
+		roles: [scouterRole],
+		profiles: [{ userID: '1', author: 'a', active: 0, assigned: ['r1'] }],
+		scoutTracker: tracker()
+	})
+
+	assert.equal(typeof member.reasons[0], 'string')
+	assert.match(member.reasons[0], /inactive/i)
+})
+
+test('assigned only loses the roles that came off in Discord', async () => {
+	const member = memberWith('1', ['r1', 'r2'], { failWith: { r2: discordError(50013) } })
+	const scoutTracker = tracker()
+
+	await stripInactiveRoles({
+		guild: guildOf({ 1: member }),
+		roles: [scouterRole, verifiedRole],
+		profiles: [{ userID: '1', author: 'a', active: 0, assigned: ['r1', 'r2'] }],
+		scoutTracker
+	})
+
+	assert.equal(scoutTracker.writes.length, 1)
+	assert.deepEqual(scoutTracker.writes[0].filter, { userID: '1' })
+	assert.deepEqual(scoutTracker.writes[0].update.$pullAll.assigned, ['r1'])
+})
+
+// The role is already gone with them, and `assigned` is the record of what they
+// held if they ever come back.
+test('someone who has left the guild is left completely alone', async () => {
+	const scoutTracker = tracker()
+
+	const entries = await stripInactiveRoles({
+		guild: guildOf({}),
+		roles: [scouterRole],
+		profiles: [{ userID: '1', author: 'a', active: 0, assigned: ['r1'] }],
+		scoutTracker
+	})
+
+	assert.deepEqual(scoutTracker.writes, [])
+	assert.deepEqual(entries, [])
+})
+
+// partitionByMembership calls a failed fetch unknown rather than departed, so a
+// rate limit must not be read as "they left" here either.
+test('a member whose fetch failed is skipped rather than stripped', async () => {
+	const scoutTracker = tracker()
+	const guild = {
+		members: {
+			fetch: async () => {
+				throw new Error('rate limited')
+			}
+		}
+	}
+
+	const entries = await stripInactiveRoles({
+		guild,
+		roles: [scouterRole],
+		profiles: [{ userID: '1', author: 'a', active: 0, assigned: ['r1'] }],
+		scoutTracker
+	})
+
+	assert.deepEqual(scoutTracker.writes, [])
+	assert.deepEqual(entries, [])
+})
+
+test('a member who left between the fetch and the removal is not written back', async () => {
+	const member = memberWith('1', ['r1'], { failWith: { r1: discordError(10007) } })
+	const scoutTracker = tracker()
+
+	await stripInactiveRoles({
+		guild: guildOf({ 1: member }),
+		roles: [scouterRole],
+		profiles: [{ userID: '1', author: 'a', active: 0, assigned: ['r1'] }],
+		scoutTracker
+	})
+
+	assert.deepEqual(scoutTracker.writes, [])
+})
+
+test('a role the member no longer holds is not removed again', async () => {
+	const member = memberWith('1', [])
+	const scoutTracker = tracker()
+
+	await stripInactiveRoles({
+		guild: guildOf({ 1: member }),
+		roles: [scouterRole],
+		profiles: [{ userID: '1', author: 'a', active: 0, assigned: ['r1'] }],
+		scoutTracker
+	})
+
+	assert.deepEqual(member.removed, [])
+	assert.deepEqual(scoutTracker.writes, [])
+})
+
+test('a role the bot cannot manage never reaches Discord', async () => {
+	const member = memberWith('1', ['r1'])
+
+	await stripInactiveRoles({
+		guild: guildOf({ 1: member }),
+		roles: [{ ...scouterRole, editable: false }],
+		profiles: [{ userID: '1', author: 'a', active: 0, assigned: ['r1'] }],
+		scoutTracker: tracker()
+	})
+
+	assert.deepEqual(member.removed, [])
+})
+
+test('nothing to strip means Discord is not asked at all', async () => {
+	const guild = guildOf({})
+
+	const entries = await stripInactiveRoles({
+		guild,
+		roles: [scouterRole],
+		profiles: [{ userID: '1', author: 'a', active: 1, assigned: ['r1'] }],
+		scoutTracker: tracker()
+	})
+
+	assert.equal(guild.fetches, 0)
+	assert.deepEqual(entries, [])
+})
+
+test('an entry names the roles that were taken off', async () => {
+	const entries = await stripInactiveRoles({
+		guild: guildOf({ 1: memberWith('1', ['r1', 'r2']) }),
+		roles: [scouterRole, verifiedRole],
+		profiles: [{ userID: '1', author: 'a', active: 0, assigned: ['r1', 'r2'] }],
+		scoutTracker: tracker()
+	})
+
+	assert.equal(entries.length, 1)
+	assert.equal(entries[0].userID, '1')
+	assert.equal(entries[0].author, 'a')
+	assert.match(entries[0].reason, /Scouter/)
+	assert.match(entries[0].reason, /Verified Scouter/)
+})
+
+// Losing a scouter role is a staffing matter, so the report goes to the owners
+// channel the same way an inactive scouter does.
+test('stripped members are reported to the owners channel', async () => {
+	const entries = await stripInactiveRoles({
+		guild: guildOf({ 1: memberWith('1', ['r1']) }),
+		roles: [scouterRole],
+		profiles: [{ userID: '1', author: 'a', active: 0, assigned: ['r1'] }],
+		scoutTracker: tracker()
+	})
+
+	const { owners, general } = splitReportAudience(entries)
+
+	assert.equal(owners.length, 1)
+	assert.deepEqual(general, [])
 })

--- a/tests/scouterRoles.test.js
+++ b/tests/scouterRoles.test.js
@@ -1,7 +1,9 @@
 import test from 'node:test'
 import assert from 'node:assert/strict'
 
-import { addedRoles, removedRoles } from '../src/dsf/scouts/scouters.js'
+import { setTimeout as delay } from 'node:timers/promises'
+
+import { addedRoles, removedRoles, syncAssignedRoles } from '../src/dsf/scouts/scouters.js'
 
 const checker = (roleName, members, roleId = 'role-1') => ({
 	roleName,
@@ -75,6 +77,48 @@ test('becoming a Verified Scouter restores the counts held in oldScout', async (
 	assert.equal(restore.update.$set.otherCount, 5)
 	assert.equal(restore.update.$set.firstTimestamp, 100)
 	assert.deepEqual(restore.update.$unset, { oldScout: 1 })
+})
+
+// `[scout, vScout].forEach(async ...)` in the cron resolved immediately, so the
+// work sequenced after it read the profiles while these writes were still in
+// flight. Same bug as the one inside addedRoles (#264), one level up.
+const slowChecker = (roleName, members, roleId) => ({
+	roleName,
+	role: Promise.resolve({ id: roleId }),
+	checkRolesAdded: async () => {
+		await delay(5)
+		return members
+	},
+	checkRolesRemoved: async () => {
+		await delay(5)
+		return members
+	}
+})
+
+test('every role is reconciled before the sweep resolves', async () => {
+	const db = tracker()
+
+	await syncAssignedRoles(
+		[slowChecker('Scouter', [{ id: '1' }], 'role-1'), slowChecker('Verified Scouter', [{ id: '1' }], 'role-2')],
+		db
+	)
+
+	// Two roles, each written once by addedRoles and once by removedRoles.
+	assert.equal(db.writes.length, 4)
+})
+
+test('a role is fully reconciled before the next one starts', async () => {
+	const db = tracker()
+
+	await syncAssignedRoles(
+		[slowChecker('Scouter', [{ id: '1' }], 'role-1'), slowChecker('Verified Scouter', [{ id: '1' }], 'role-2')],
+		db
+	)
+
+	assert.deepEqual(
+		db.writes.map((write) => write.update.$addToSet?.assigned ?? write.update.$pull?.assigned),
+		['role-1', 'role-1', 'role-2', 'role-2']
+	)
 })
 
 test('a profile with no oldScout is left alone', async () => {

--- a/tests/scouterThresholds.test.js
+++ b/tests/scouterThresholds.test.js
@@ -82,6 +82,29 @@ test('someone with no roles is not a verified scouter candidate', () => {
 	assert.equal(checker()._checkVerifiedScouts(none, 10, MONTH), undefined)
 })
 
+// Stripping the role on inactivity clears `assigned`, and an ex-scouter's counts
+// are well past the threshold — so without this they come straight back as a
+// "potential scouter" in the next weekly embed.
+test('an inactive profile is not proposed for the scouter role', () => {
+	const stripped = profile({ otherCount: 50, active: 0 })
+
+	assert.equal(checker()._checkScouts(stripped, 10, MONTH), undefined)
+})
+
+test('an inactive profile is not proposed for the verified scouter role', () => {
+	const stripped = profile({ otherCount: 50, assigned: ['Scouter'], active: 0 })
+
+	assert.equal(checker()._checkVerifiedScouts(stripped, 10, MONTH), undefined)
+})
+
+// Only an explicit 0 excludes anyone: documents predating the flag have no
+// `active` field, and they are not inactive.
+test('a profile predating the active flag still qualifies', () => {
+	const legacy = profile({ otherCount: 50 })
+
+	assert.notEqual(checker()._checkScouts(legacy, 10, MONTH), undefined)
+})
+
 test('a profile missing its timestamps is skipped rather than crashing', () => {
 	const undated = { count: 50, assigned: [] }
 


### PR DESCRIPTION
## What

Marking a profile inactive never touched Discord, so an inactive scouter kept the role and its permissions until someone removed it by hand. The 6-hourly sweep now takes Scouter and Verified Scouter off every profile sitting at `active: 0` — what each run marks, plus the backlog earlier runs left behind (~80 profiles hold a role, not the full 2362 marked).

## How

New in `src/dsf/scouts/membership.js`:

- `selectStrippable` — `active === 0 && assigned.length > 0`
- `strippableRoles` — drops `managed` and non-`editable` roles once per run
- `stripInactiveRoles` — removes the roles, `$pullAll`s what Discord accepted, returns owners-channel report entries

`partitionByMembership` now also returns the members it fetched, so stripping reuses that batch instead of fetching once per candidate.

## Safety

- **Nobody absent is written to.** Departed members' roles left with them; `assigned` stays as the record of what they held. A member whose fetch failed is unknown rather than gone — same rule `partitionByMembership` already applies.
- **`$pullAll` only covers roles Discord actually removed**, so a partial failure leaves the database agreeing with the guild. `50013` logs and skips; `10007` is treated as departed.
- **Hierarchy is checked once per role.** Discord checks the position of the role being changed, not the target's own highest role, so `role.editable` is the whole question — checking it per run turns a 403 per member into one warning.
- **Only an explicit `active: 0` excludes anyone.** Documents predating the flag have no `active` field and are not inactive; reading them as inactive would strip roles from working scouters.

## Regression this would have caused

Stripping empties `assigned` while an ex-scouter's counts stay well past the threshold, so the weekly "potential scouters" embed would propose everyone the sweep just removed. `_checkScouts` and `_checkVerifiedScouts` now skip inactive profiles.

## Also in here

`[scout, vScout].forEach(async ...)` in the cron resolved immediately, so `updateAllMemberDataBaseRankRoles` read the profiles while the role writes were still in flight, and a failure inside became an unhandled rejection. Replaced with an awaited `syncAssignedRoles`. Same bug as #264, one level up.

## Testing

TDD throughout — every test watched fail first. `npm test`: **351 tests, 351 pass, 0 fail**. Prettier clean; eslint 0 errors (the 1 warning is pre-existing in `counts.js:162`).

New coverage: role above the bot / managed role never reaching Discord, departed and fetch-failed members skipped with no write, `50013` and `10007` tolerated, `$pullAll` limited to roles actually removed, legacy profiles left alone, both roles reconciled in order before the sweep resolves.

Not verified against production Discord — role positions should be confirmed (ValenceBot's role must sit above Verified Scouter) or the first run just logs warnings and strips nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)